### PR TITLE
chore: update transifex scripts to api v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,9 @@
-transifex_resource = frontend-app-authn
+export TRANSIFEX_RESOURCE = frontend-app-authn
 transifex_langs = "ar,fr,es_419,zh_CN"
 
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
 transifex_input = $(i18n)/transifex_input.json
-tx_url1 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/translation/en/strings/
-tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/$(transifex_resource)/source/
 
 # This directory must match .babelrc .
 transifex_temp = ./temp/babel-plugin-react-intl
@@ -38,11 +36,11 @@ push_translations:
 	# Pushing strings to Transifex...
 	tx push -s
 	# Fetching hashes from Transifex...
-	./node_modules/reactifex/bash_scripts/get_hashed_strings.sh $(tx_url1)
+	./node_modules/@edx/reactifex/bash_scripts/get_hashed_strings_v3.sh
 	# Writing out comments to file...
-	$(transifex_utils) $(transifex_temp) --comments
+	$(transifex_utils) $(transifex_temp) --comments --v3-scripts-path
 	# Pushing comments to Transifex...
-	./node_modules/reactifex/bash_scripts/put_comments.sh $(tx_url2)
+	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
 
 # Pulls translations from Transifex.
 pull_translations:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3600,6 +3600,65 @@
         "uncontrollable": "7.2.1"
       }
     },
+    "@edx/reactifex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-1.0.3.tgz",
+      "integrity": "sha512-zJjD3ym4KOQ2sa+lwR08jgospMyiRTSRqK6Mxi1VMQ+sqxZxWFCGymV+mqLRPHPAJ/z+qhblsVuWeb0N9qI5ww==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.21.1",
+        "yargs": "^17.1.1"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "yargs": {
+          "version": "17.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.3.1.tgz",
+          "integrity": "sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+          "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+          "dev": true
+        }
+      }
+    },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
@@ -18215,12 +18274,6 @@
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       }
-    },
-    "reactifex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/reactifex/-/reactifex-1.1.1.tgz",
-      "integrity": "sha512-HH2N/b5tRxh7ypIgCRsiBl/CTxRkTEPf9DhIstaM6hne4WiwM5/bBbWuvVlRZc/i3FdqZED3pZ//6n4mtxma4w==",
-      "dev": true
     },
     "read-babelrc-up": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@edx/frontend-build": "9.0.6",
+    "@edx/reactifex": "1.0.3",
     "babel-plugin-react-intl": "8.2.25",
     "codecov": "3.8.2",
     "enzyme": "3.11.0",
@@ -86,7 +87,6 @@
     "history": "5.2.0",
     "husky": "7.0.4",
     "jest": "27.5.1",
-    "react-test-renderer": "16.14.0",
-    "reactifex": "1.1.1"
+    "react-test-renderer": "16.14.0"
   }
 }

--- a/src/login/messages.jsx
+++ b/src/login/messages.jsx
@@ -20,7 +20,7 @@ const messages = defineMessages({
   'sign.in.button': {
     id: 'sign.in.button',
     defaultMessage: 'Sign in',
-    description: 'Button label that appears on login page',
+    description: 'Sign in button label that appears on login page',
   },
   'sign.in.btn.pending.state': {
     id: 'sign.in.btn.pending.state',


### PR DESCRIPTION
As of April 7th, 2022 the API versions 2 and 2.5 will no longer be operational and relevant requests will begin to fail. Switched to `@edx/reactifex` from `reactifex` which does support V3.

VAN-894