### PR TITLE
fix: password reset page spinner position

### DIFF
--- a/src/reset-password/ResetPasswordPage.jsx
+++ b/src/reset-password/ResetPasswordPage.jsx
@@ -148,7 +148,7 @@ const ResetPasswordPage = (props) => {
     const { token } = props.match.params;
     if (token) {
       props.validateToken(token);
-      return <Spinner animation="border" variant="primary" className="mt-5" />;
+      return <Spinner animation="border" variant="primary" className="centered-align-spinner" />;
     }
   } else if (props.status === PASSWORD_RESET_ERROR) {
     return <Redirect to={updatePathWithQueryParams(RESET_PAGE)} />;


### PR DESCRIPTION
The spinner that appears on the `Password Reset Page` should be centred aligned

|Before|After|
|-------|------|
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/40633976/159894823-4912d47d-0631-4ec0-94ca-8252533ccde4.gif)|![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/40633976/159894938-a04c0885-1675-400e-a4f5-0f3cc0a76b17.gif)

