### PR TITLE
fix: button width

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -42,7 +42,7 @@ $accent-a-light: #c9f2f5;
 }
 
 .login-button-width {
-  width: 6rem;
+  min-width: 6rem;
 }
 
 .tpa-skeleton {


### PR DESCRIPTION
Text fit in login button

<img width="173" alt="Screen Shot 2022-04-20 at 5 21 08 PM" src="https://user-images.githubusercontent.com/78487564/164291204-06db20f1-f83e-4e6c-8e7d-f7ef6d50d563.png">

VAN-889