### PR TITLE
fix: Update position of cross icon on username field

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -866,7 +866,7 @@ select.form-control {
   margin-left: 15px;
 }
 .suggested-username-close-button {
-  right: 0;
+  right: 1rem;
   position: absolute;
 }
 .suggested-username-with-error {


### PR DESCRIPTION
The Cross icon was overlapping the border of the username field when username suggestions were generated,
This PR fixes the position of the cross icon of username suggestions field

[VAN-936](https://openedx.atlassian.net/browse/VAN-936)

**Before**

<img width="516" alt="Screen Shot 2022-04-22 at 2 48 45 PM" src="https://user-images.githubusercontent.com/52817156/165273830-b4248ca4-77e0-4eb1-9f2d-394470764686.png">

**After**

<img width="542" alt="Screen Shot 2022-04-26 at 1 22 35 PM" src="https://user-images.githubusercontent.com/52817156/165273896-427c6dfe-c203-4bd5-b46a-1dd64af47488.png">
