### PR TITLE
fix: Styling issue in fields trailing element

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -881,3 +881,7 @@ select.form-control {
   overflow-x: auto;
   display: inline-flex;
 }
+
+.pgn__form-control-decorator-trailing {
+  right: 0 !important;
+}


### PR DESCRIPTION
The trailing element in a field is out of position in some browsers that do not support `inset-inline-end` property such as Safari version 13 and less. This PR fixes this problem for all browsers

**Before**

<img width="549" alt="Screen Shot 2022-04-28 at 6 26 24 PM" src="https://user-images.githubusercontent.com/52817156/165762932-4e70d782-7e86-4bc1-9f9b-3af0fda2e219.png">

**After**

<img width="580" alt="Screen Shot 2022-04-28 at 6 26 46 PM" src="https://user-images.githubusercontent.com/52817156/165762972-a52b8673-e248-4e7b-8986-563fbb287081.png">
