### PR TITLE
fix: Persist Register/Sign In form states on tab switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [16]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -1,0 +1,13 @@
+#check package-lock file version
+
+name: Lockfile Version check
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  version-check:
+    uses: edx/.github/.github/workflows/lockfileversion-check.yml@master

--- a/src/base-component/LargeLeftLayout.jsx
+++ b/src/base-component/LargeLeftLayout.jsx
@@ -20,51 +20,53 @@ const LargeLeftLayout = (props) => {
   new ClipboardJS('.copyIcon'); // eslint-disable-line no-new
 
   return (
-    <div className="min-vh-100 pr-0 mt-lg-n2 d-flex align-items-center">
-      <Toast
-        onClose={() => setToastShow(false)}
-        show={showToast}
-      >
-        {intl.formatMessage(messages['code.copied'])}
-      </Toast>
-      <svg className={classNames(
-        'large-screen-svg-line',
-        {
-          'variation1-bar-color mt-n6 pt-0 ml-5': experimentName === 'variation1' && isRegistrationPage,
-          'variation2-bar-color': experimentName === 'variation2' && isRegistrationPage,
-          'ml-5': experimentName !== 'variation1' || !isRegistrationPage,
-        },
-      )}
-      >
-        <line x1="50" y1="0" x2="10" y2="215" />
-      </svg>
-      <div className={classNames({ 'pl-4': experimentName === 'variation1' && isRegistrationPage })}>
-        <h1 className={classNames('large-heading', { 'mb-4.5': experimentName === 'variation1' && isRegistrationPage })}>
-          {intl.formatMessage(messages['start.learning'])}
-          <span
-            className={((experimentName === 'variation1' || experimentName === 'variation2') && isRegistrationPage) ? 'text-accent-b' : 'text-accent-a'}
-          >
-            <br />
-            {intl.formatMessage(messages['with.site.name'], { siteName: getConfig().SITE_NAME })}
-          </span>
-        </h1>
-        {experimentName === 'variation1' && isRegistrationPage ? (
-          <span className="text-light-300 dicount-heading">
-            <span className="lead mr-3">
-              <SideDiscountBanner />
+    <div className="min-vh-100 d-flex justify-content-left align-items-center">
+      <div className="d-flex pr-0 mt-lg-n2">
+        <Toast
+          onClose={() => setToastShow(false)}
+          show={showToast}
+        >
+          {intl.formatMessage(messages['code.copied'])}
+        </Toast>
+        <svg className={classNames(
+          'large-screen-svg-line',
+          {
+            'variation1-bar-color mt-n6 pt-0 ml-5': experimentName === 'variation1' && isRegistrationPage,
+            'variation2-bar-color': experimentName === 'variation2' && isRegistrationPage,
+            'ml-5': experimentName !== 'variation1' || !isRegistrationPage,
+          },
+        )}
+        >
+          <line x1="50" y1="0" x2="10" y2="215" />
+        </svg>
+        <div className={classNames({ 'pl-4': experimentName === 'variation1' && isRegistrationPage })}>
+          <h1 className={classNames('large-heading', { 'mb-4.5': experimentName === 'variation1' && isRegistrationPage })}>
+            {intl.formatMessage(messages['start.learning'])}
+            <span
+              className={((experimentName === 'variation1' || experimentName === 'variation2') && isRegistrationPage) ? 'text-accent-b' : 'text-accent-a'}
+            >
+              <br />
+              {intl.formatMessage(messages['with.site.name'], { siteName: getConfig().SITE_NAME })}
             </span>
-            <span className="dashed-border d-inline-flex flex-wrap align-items-center">
-              <span id="edx-welcome" className="text-white edx-welcome font-weight-bold mr-1">EDXWELCOME</span>
-              <FontAwesomeIcon
-                className="text-light-700 copyIcon ml-1.5 hover-discount-icon"
-                icon={faCut}
-                data-clipboard-action="copy"
-                data-clipboard-target="#edx-welcome"
-                onClick={() => setToastShow(true)}
-              />
+          </h1>
+          {experimentName === 'variation1' && isRegistrationPage ? (
+            <span className="text-light-300 dicount-heading">
+              <span className="lead mr-3">
+                <SideDiscountBanner />
+              </span>
+              <span className="dashed-border d-inline-flex flex-wrap align-items-center">
+                <span id="edx-welcome" className="text-white edx-welcome font-weight-bold mr-1">EDXWELCOME</span>
+                <FontAwesomeIcon
+                  className="text-light-700 copyIcon ml-1.5 hover-discount-icon"
+                  icon={faCut}
+                  data-clipboard-action="copy"
+                  data-clipboard-target="#edx-welcome"
+                  onClick={() => setToastShow(true)}
+                />
+              </span>
             </span>
-          </span>
-        ) : null}
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/src/common-components/FormGroup.jsx
+++ b/src/common-components/FormGroup.jsx
@@ -26,6 +26,7 @@ const FormGroup = (props) => {
         as={props.as}
         readOnly={props.readOnly}
         type={props.type}
+        aria-invalid={props.errorMessage !== ''}
         className="form-field"
         autoComplete={props.autoComplete}
         name={props.name}

--- a/src/common-components/PasswordField.jsx
+++ b/src/common-components/PasswordField.jsx
@@ -63,6 +63,7 @@ const PasswordField = (props) => {
           type={isPasswordHidden ? 'password' : 'text'}
           name={props.name}
           value={props.value}
+          aria-invalid={props.errorMessage !== ''}
           onFocus={handleFocus}
           onBlur={handleBlur}
           onChange={props.handleChange}

--- a/src/forgot-password/ForgotPasswordPage.jsx
+++ b/src/forgot-password/ForgotPasswordPage.jsx
@@ -97,7 +97,7 @@ const ForgotPasswordPage = (props) => {
                     { siteName: getConfig().SITE_NAME })}
                   </title>
                 </Helmet>
-                <Form className="mw-xs">
+                <Form id="forget-password-form" name="forget-password-form" className="mw-xs">
                   <ForgotPasswordAlert email={props.email} emailError={errors.email} status={status} />
                   <h2 className="h4">
                     {intl.formatMessage(messages['forgot.password.page.heading'])}
@@ -116,6 +116,8 @@ const ForgotPasswordPage = (props) => {
                     helpText={[intl.formatMessage(messages['forgot.password.email.help.text'], { platformName })]}
                   />
                   <StatefulButton
+                    id="submit-forget-password"
+                    name="submit-forget-password"
                     type="submit"
                     variant="brand"
                     className="login-button-width"
@@ -129,6 +131,7 @@ const ForgotPasswordPage = (props) => {
                   />
                   <Hyperlink
                     id="forgot-password"
+                    name="forgot-password"
                     className="ml-4 font-weight-500 text-body"
                     destination={supportUrl}
                     onClick={e => {

--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -129,7 +129,6 @@
   "help.text.username.1": "The name that will identify you in your courses.",
   "help.text.username.2": "This can not be changed later.",
   "help.text.email": "For account activation and important updates",
-  "create.account.button": "Create an account",
   "create.account.for.free.button": "Create an account for free",
   "create.an.account.btn.pending.state": "Loading",
   "registration.other.options.heading": "Or register with:",

--- a/src/i18n/messages/de_DE.json
+++ b/src/i18n/messages/de_DE.json
@@ -129,7 +129,6 @@
   "help.text.username.1": "The name that will identify you in your courses.",
   "help.text.username.2": "This can not be changed later.",
   "help.text.email": "For account activation and important updates",
-  "create.account.button": "Create an account",
   "create.account.for.free.button": "Create an account for free",
   "create.an.account.btn.pending.state": "Loading",
   "registration.other.options.heading": "Or register with:",

--- a/src/i18n/messages/es_419.json
+++ b/src/i18n/messages/es_419.json
@@ -129,7 +129,6 @@
   "help.text.username.1": "El nombre que te identificará en tus cursos.",
   "help.text.username.2": "Esto no puede modificarse posteriormente.",
   "help.text.email": "Para la activación de la cuenta y las actualizaciones importantes",
-  "create.account.button": "Crear una cuenta",
   "create.account.for.free.button": "Crea una cuenta gratis",
   "create.an.account.btn.pending.state": "Cargando",
   "registration.other.options.heading": "O regístrese con:",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -129,7 +129,6 @@
   "help.text.username.1": "Le nom qui vous identifiera dans vos cours.",
   "help.text.username.2": "Cela ne peut pas être modifié ultérieurement.",
   "help.text.email": "Pour l'activation du compte et les mises à jour importantes",
-  "create.account.button": "Créer un compte",
   "create.account.for.free.button": "Créer un compte gratuitement",
   "create.an.account.btn.pending.state": "Chargement en cours",
   "registration.other.options.heading": "Ou inscrivez-vous avec :",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -129,7 +129,6 @@
   "help.text.username.1": "The name that will identify you in your courses.",
   "help.text.username.2": "This can not be changed later.",
   "help.text.email": "For account activation and important updates",
-  "create.account.button": "Create an account",
   "create.account.for.free.button": "Create an account for free",
   "create.an.account.btn.pending.state": "Loading",
   "registration.other.options.heading": "Or register with:",

--- a/src/i18n/messages/it_IT.json
+++ b/src/i18n/messages/it_IT.json
@@ -129,7 +129,6 @@
   "help.text.username.1": "The name that will identify you in your courses.",
   "help.text.username.2": "This can not be changed later.",
   "help.text.email": "For account activation and important updates",
-  "create.account.button": "Create an account",
   "create.account.for.free.button": "Create an account for free",
   "create.an.account.btn.pending.state": "Loading",
   "registration.other.options.heading": "Or register with:",

--- a/src/i18n/messages/pt_PT.json
+++ b/src/i18n/messages/pt_PT.json
@@ -129,7 +129,6 @@
   "help.text.username.1": "The name that will identify you in your courses.",
   "help.text.username.2": "This can not be changed later.",
   "help.text.email": "For account activation and important updates",
-  "create.account.button": "Create an account",
   "create.account.for.free.button": "Create an account for free",
   "create.an.account.btn.pending.state": "Loading",
   "registration.other.options.heading": "Or register with:",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -129,7 +129,6 @@
   "help.text.username.1": "The name that will identify you in your courses.",
   "help.text.username.2": "This can not be changed later.",
   "help.text.email": "For account activation and important updates",
-  "create.account.button": "Create an account",
   "create.account.for.free.button": "Create an account for free",
   "create.an.account.btn.pending.state": "Loading",
   "registration.other.options.heading": "Or register with:",

--- a/src/i18n/messages/uk.json
+++ b/src/i18n/messages/uk.json
@@ -129,7 +129,6 @@
   "help.text.username.1": "The name that will identify you in your courses.",
   "help.text.username.2": "This can not be changed later.",
   "help.text.email": "For account activation and important updates",
-  "create.account.button": "Create an account",
   "create.account.for.free.button": "Create an account for free",
   "create.an.account.btn.pending.state": "Loading",
   "registration.other.options.heading": "Or register with:",

--- a/src/i18n/messages/zh_CN.json
+++ b/src/i18n/messages/zh_CN.json
@@ -129,7 +129,6 @@
   "help.text.username.1": "The name that will identify you in your courses.",
   "help.text.username.2": "This can not be changed later.",
   "help.text.email": "For account activation and important updates",
-  "create.account.button": "Create an account",
   "create.account.for.free.button": "Create an account for free",
   "create.an.account.btn.pending.state": "Loading",
   "registration.other.options.heading": "Or register with:",

--- a/src/login/LoginPage.jsx
+++ b/src/login/LoginPage.jsx
@@ -224,7 +224,7 @@ class LoginPage extends React.Component {
           {submitState === DEFAULT_STATE && this.state.isSubmitted ? windowScrollTo({ left: 0, top: 0, behavior: 'smooth' }) : null}
           {activationMsgType && <AccountActivationMessage messageType={activationMsgType} />}
           {this.props.resetPassword && !this.props.loginError ? <ResetPasswordSuccess /> : null}
-          <Form>
+          <Form name="sign-in-form" id="sign-in-form">
             <FormGroup
               name="emailOrUsername"
               value={this.state.emailOrUsername}
@@ -243,6 +243,8 @@ class LoginPage extends React.Component {
               floatingLabel={intl.formatMessage(messages['login.password.label'])}
             />
             <StatefulButton
+              name="sign-in"
+              id="sign-in"
               type="submit"
               variant="brand"
               className="login-button-width"
@@ -256,6 +258,7 @@ class LoginPage extends React.Component {
             />
             <Link
               id="forgot-password"
+              name="forgot-password"
               className="btn btn-link font-weight-500 text-body"
               to={updatePathWithQueryParams(RESET_PAGE)}
               onClick={this.handleForgotPasswordLinkClickEvent}

--- a/src/login/data/actions.js
+++ b/src/login/data/actions.js
@@ -1,6 +1,7 @@
 import { AsyncActionType } from '../../data/utils';
 
 export const LOGIN_REQUEST = new AsyncActionType('LOGIN', 'REQUEST');
+export const LOGIN_SET_FORM_DATA = 'LOGIN_PERSIST_FORM_DATA';
 
 // Login
 export const loginRequest = creds => ({
@@ -24,4 +25,10 @@ export const loginRequestFailure = (loginError) => ({
 
 export const loginRequestReset = () => ({
   type: LOGIN_REQUEST.RESET,
+});
+
+// Persist Form Data
+export const loginSetFormData = (formData) => ({
+  type: LOGIN_SET_FORM_DATA,
+  payload: { formData },
 });

--- a/src/login/data/reducers.js
+++ b/src/login/data/reducers.js
@@ -1,4 +1,4 @@
-import { LOGIN_REQUEST } from './actions';
+import { LOGIN_REQUEST, LOGIN_SET_FORM_DATA } from './actions';
 
 import { DEFAULT_STATE, PENDING_STATE } from '../../data/constants';
 import { RESET_PASSWORD } from '../../reset-password';
@@ -7,6 +7,14 @@ export const defaultState = {
   loginError: null,
   loginResult: {},
   resetPassword: false,
+  formData: {
+    password: '',
+    emailOrUsername: '',
+    errors: {
+      emailOrUsername: '',
+      password: '',
+    },
+  },
 };
 
 const reducer = (state = defaultState, action) => {
@@ -38,6 +46,13 @@ const reducer = (state = defaultState, action) => {
         ...state,
         resetPassword: true,
       };
+    case LOGIN_SET_FORM_DATA: {
+      const { formData } = action.payload;
+      return {
+        ...state,
+        formData,
+      };
+    }
     default:
       return {
         ...state,

--- a/src/login/data/selectors.js
+++ b/src/login/data/selectors.js
@@ -13,3 +13,8 @@ export const loginErrorSelector = createSelector(
   loginSelector,
   login => login.loginError,
 );
+
+export const loginFormDataSelector = createSelector(
+  loginSelector,
+  login => login.formData,
+);

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -552,7 +552,7 @@ class RegistrationPage extends React.Component {
               <h4 className="mt-4 mb-4">{intl.formatMessage(messages['registration.using.tpa.form.heading'])}</h4>
             </>
           )}
-          <Form>
+          <Form id="registration-form" name="registration-form">
             <FormGroup
               name="name"
               value={this.state.name}
@@ -649,6 +649,8 @@ class RegistrationPage extends React.Component {
               />
             </div>
             <StatefulButton
+              name="register-user"
+              id="register-user"
               type="submit"
               variant="brand"
               className="register-stateful-button-width mt-4 mb-4"

--- a/src/register/data/actions.js
+++ b/src/register/data/actions.js
@@ -4,6 +4,7 @@ export const REGISTER_NEW_USER = new AsyncActionType('REGISTRATION', 'REGISTER_N
 export const REGISTER_FORM_VALIDATIONS = new AsyncActionType('REGISTRATION', 'GET_FORM_VALIDATIONS');
 export const REGISTRATION_FORM = new AsyncActionType('REGISTRATION', 'REGISTRATION_FORM');
 export const REGISTER_CLEAR_USERNAME_SUGGESTIONS = 'REGISTRATION_CLEAR_USERNAME_SUGGESTIONS';
+export const REGISTER_SET_FORM_DATA = 'REGISTER_SET_FORM_DATA';
 
 // Reset Form
 export const resetRegistrationForm = () => ({
@@ -52,4 +53,10 @@ export const fetchRealtimeValidationsFailure = () => ({
 
 export const clearUsernameSuggestions = () => ({
   type: REGISTER_CLEAR_USERNAME_SUGGESTIONS,
+});
+
+// Persist Form Data
+export const registerSetFormData = (formData) => ({
+  type: REGISTER_SET_FORM_DATA,
+  payload: { formData },
 });

--- a/src/register/data/reducers.js
+++ b/src/register/data/reducers.js
@@ -1,5 +1,6 @@
 import {
   REGISTRATION_FORM, REGISTER_NEW_USER, REGISTER_FORM_VALIDATIONS, REGISTER_CLEAR_USERNAME_SUGGESTIONS,
+  REGISTER_SET_FORM_DATA,
 } from './actions';
 
 import { DEFAULT_STATE, PENDING_STATE } from '../../data/constants';
@@ -7,7 +8,23 @@ import { DEFAULT_STATE, PENDING_STATE } from '../../data/constants';
 export const defaultState = {
   registrationError: {},
   registrationResult: {},
-  formData: null,
+  formData: {
+    country: '',
+    email: '',
+    name: '',
+    password: '',
+    username: '',
+    marketingOptIn: true,
+    errors: {
+      email: '',
+      name: '',
+      username: '',
+      password: '',
+      country: '',
+    },
+    emailErrorSuggestion: null,
+    emailWarningSuggestion: null,
+  },
   validations: null,
   statusCode: null,
   usernameSuggestions: [],
@@ -18,6 +35,8 @@ const reducer = (state = defaultState, action) => {
     case REGISTRATION_FORM.RESET:
       return {
         ...defaultState,
+        formData: state.formData,
+        usernameSuggestions: state.usernameSuggestions,
       };
     case REGISTER_NEW_USER.BEGIN:
       return {
@@ -63,6 +82,13 @@ const reducer = (state = defaultState, action) => {
         ...state,
         usernameSuggestions: [],
       };
+    case REGISTER_SET_FORM_DATA: {
+      const { formData } = action.payload;
+      return {
+        ...state,
+        formData,
+      };
+    }
     default:
       return state;
   }

--- a/src/register/data/selectors.js
+++ b/src/register/data/selectors.js
@@ -41,3 +41,8 @@ export const usernameSuggestionsSelector = createSelector(
   registerSelector,
   register => register.usernameSuggestions,
 );
+
+export const registerFormDataSelector = createSelector(
+  registerSelector,
+  register => register.formData,
+);

--- a/src/register/data/tests/reducers.test.js
+++ b/src/register/data/tests/reducers.test.js
@@ -1,6 +1,10 @@
 import reducer from '../reducers';
 import {
-  REGISTER_CLEAR_USERNAME_SUGGESTIONS, REGISTER_FORM_VALIDATIONS, REGISTER_NEW_USER,
+  REGISTER_CLEAR_USERNAME_SUGGESTIONS,
+  REGISTER_FORM_VALIDATIONS,
+  REGISTER_NEW_USER,
+  REGISTER_SET_FORM_DATA,
+  REGISTRATION_FORM,
 } from '../actions';
 import { DEFAULT_STATE } from '../../../data/constants';
 
@@ -10,7 +14,23 @@ describe('register reducer', () => {
       {
         registrationError: {},
         registrationResult: {},
-        formData: null,
+        formData: {
+          country: '',
+          email: '',
+          name: '',
+          password: '',
+          username: '',
+          marketingOptIn: true,
+          errors: {
+            email: '',
+            name: '',
+            username: '',
+            password: '',
+            country: '',
+          },
+          emailErrorSuggestion: null,
+          emailWarningSuggestion: null,
+        },
         validations: null,
         statusCode: null,
         usernameSuggestions: [],
@@ -68,6 +88,141 @@ describe('register reducer', () => {
       reducer(state, action),
     ).toEqual(
       {
+        usernameSuggestions: [],
+      },
+    );
+  });
+  it('should not reset username suggestions and form data in form reset', () => {
+    const state = {
+      registrationError: {},
+      registrationResult: {},
+      formData: {
+        country: 'Pakistan',
+        email: 'test@email.com',
+        name: 'John Doe',
+        password: 'johndoe',
+        username: 'john',
+        marketingOptIn: true,
+        errors: {
+          email: '',
+          name: '',
+          username: '',
+          password: '',
+          country: '',
+        },
+        emailErrorSuggestion: 'test@email.com',
+        emailWarningSuggestion: 'test@email.com',
+      },
+      validations: null,
+      statusCode: null,
+      usernameSuggestions: [],
+    };
+    const action = {
+      type: REGISTRATION_FORM.RESET,
+    };
+
+    expect(
+      reducer(state, action),
+    ).toEqual(
+      {
+        registrationError: {},
+        registrationResult: {},
+        formData: {
+          country: 'Pakistan',
+          email: 'test@email.com',
+          name: 'John Doe',
+          password: 'johndoe',
+          username: 'john',
+          marketingOptIn: true,
+          errors: {
+            email: '',
+            name: '',
+            username: '',
+            password: '',
+            country: '',
+          },
+          emailErrorSuggestion: 'test@email.com',
+          emailWarningSuggestion: 'test@email.com',
+        },
+        validations: null,
+        statusCode: null,
+        usernameSuggestions: [],
+      },
+    );
+  });
+
+  it('should set formData', () => {
+    const state = {
+      registrationError: {},
+      registrationResult: {},
+      formData: {
+        country: '',
+        email: '',
+        name: '',
+        password: '',
+        username: '',
+        marketingOptIn: true,
+        errors: {
+          email: '',
+          name: '',
+          username: '',
+          password: '',
+          country: '',
+        },
+        emailErrorSuggestion: null,
+        emailWarningSuggestion: null,
+      },
+      validations: null,
+      statusCode: null,
+      usernameSuggestions: [],
+    };
+    const formData = {
+      country: 'Pakistan',
+      email: 'test@email.com',
+      name: 'John Doe',
+      password: 'johndoe',
+      username: 'john',
+      marketingOptIn: true,
+      errors: {
+        email: '',
+        name: '',
+        username: '',
+        password: '',
+        country: '',
+      },
+      emailErrorSuggestion: 'test@email.com',
+      emailWarningSuggestion: 'test@email.com',
+    };
+    const action = {
+      type: REGISTER_SET_FORM_DATA,
+      payload: { formData },
+    };
+
+    expect(
+      reducer(state, action),
+    ).toEqual(
+      {
+        registrationError: {},
+        registrationResult: {},
+        formData: {
+          country: 'Pakistan',
+          email: 'test@email.com',
+          name: 'John Doe',
+          password: 'johndoe',
+          username: 'john',
+          marketingOptIn: true,
+          errors: {
+            email: '',
+            name: '',
+            username: '',
+            password: '',
+            country: '',
+          },
+          emailErrorSuggestion: 'test@email.com',
+          emailWarningSuggestion: 'test@email.com',
+        },
+        validations: null,
+        statusCode: null,
         usernameSuggestions: [],
       },
     );

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -13,7 +13,7 @@ import { IntlProvider, injectIntl, configure } from '@edx/frontend-platform/i18n
 import {
   clearUsernameSuggestions,
   fetchRealtimeValidations,
-  registerNewUser,
+  registerNewUser, registerSetFormData,
   resetRegistrationForm,
 } from '../data/actions';
 import { FORBIDDEN_REQUEST, INTERNAL_SERVER_ERROR, TPA_SESSION_EXPIRED } from '../data/constants';
@@ -771,6 +771,32 @@ describe('RegistrationPage', () => {
       mergeConfig({
         MARKETING_EMAILS_OPT_IN: '',
       });
+    });
+
+    // ******** persist state tests ********
+
+    it.only('should set form data in redux store on onFocus', () => {
+      const formData = {
+        country: '',
+        email: '',
+        name: '',
+        password: '',
+        username: '',
+        marketingOptIn: true,
+        errors: {
+          email: '',
+          name: '',
+          username: '',
+          password: '',
+          country: '',
+        },
+        emailErrorSuggestion: null,
+        emailWarningSuggestion: null,
+      };
+      store.dispatch = jest.fn(store.dispatch);
+      const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
+      registrationPage.find('input#name').simulate('focus');
+      expect(store.dispatch).toHaveBeenCalledWith(registerSetFormData(formData));
     });
   });
 });

--- a/src/reset-password/ResetPasswordPage.jsx
+++ b/src/reset-password/ResetPasswordPage.jsx
@@ -174,7 +174,7 @@ const ResetPasswordPage = (props) => {
               <ResetPasswordFailure errorCode={errorCode} errorMsg={props.errorMsg} />
               <h4>{intl.formatMessage(messages['reset.password'])}</h4>
               <p className="mb-4">{intl.formatMessage(messages['reset.password.page.instructions'])}</p>
-              <Form>
+              <Form id="set-reset-password-form" name="set-reset-password-form">
                 <PasswordField
                   name="newPassword"
                   value={newPassword}
@@ -194,6 +194,8 @@ const ResetPasswordPage = (props) => {
                   floatingLabel={intl.formatMessage(messages['confirm.password.label'])}
                 />
                 <StatefulButton
+                  id="submit-new-password"
+                  name="submit-new-password"
                   type="submit"
                   variant="brand"
                   className="stateful-button-width"

--- a/src/welcome/WelcomePage.jsx
+++ b/src/welcome/WelcomePage.jsx
@@ -162,7 +162,7 @@ const WelcomePage = (props) => {
               <p>{intl.formatMessage(messages['welcome.page.error.message'])}</p>
             </Alert>
           ) : null}
-          <Form>
+          <Form id="welcome-page-profile-form" name="welcome-page-profile-form">
             <Form.Group controlId="levelOfEducation">
               <Form.Control
                 as="select"
@@ -217,6 +217,8 @@ const WelcomePage = (props) => {
             </span>
             <div className="d-flex mt-4">
               <StatefulButton
+                name="submit-profile"
+                id="submit-profile"
                 type="submit"
                 variant="brand"
                 className="login-button-width"
@@ -229,6 +231,8 @@ const WelcomePage = (props) => {
                 onMouseDown={(e) => e.preventDefault()}
               />
               <StatefulButton
+                id="skip-profile"
+                name="skip-profile"
                 className="text-gray-700 font-weight-500"
                 type="submit"
                 variant="link"


### PR DESCRIPTION
**Before:**
When the user switched tab from register to sign or vice versa, the fill data in the form was lost

**After:**
Data entered in the form is persisted on tab switching.

[VAN-618](https://2u-internal.atlassian.net/browse/VAN-618)