### PR TITLE
fix: password tooltip should use extra small font size

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -296,8 +296,10 @@ select.form-control {
 .tooltip-shadow {
   box-shadow: 0px 5px 15px 0px rgba(0,0,0,0.3) !important;
 }
+
 #password-requirement-left {
   opacity: 1;
+  @extend .x-small;
   .tooltip-inner {
     @extend .tooltip-shadow;
     background: white;
@@ -315,6 +317,7 @@ select.form-control {
   opacity: 1;
   width: 90%;
   margin-bottom: 10px;
+  @extend .x-small;
   .tooltip-inner {
     max-width: inherit;
     background: white;

--- a/src/common-components/PasswordField.jsx
+++ b/src/common-components/PasswordField.jsx
@@ -39,15 +39,15 @@ const PasswordField = (props) => {
   const placement = window.innerWidth < 768 ? 'top' : 'left';
   const tooltip = (
     <Tooltip id={`password-requirement-${placement}`}>
-      <span id="letter-check" className="d-flex position-relative align-content-start">
+      <span id="letter-check" className="d-flex align-items-center">
         {LETTER_REGEX.test(props.value) ? <Icon className="text-success mr-1" src={Check} /> : <Icon className="mr-1 text-light-700" src={Remove} />}
         {formatMessage(messages['one.letter'])}
       </span>
-      <span id="number-check" className="d-flex position-relative align-content-start">
+      <span id="number-check" className="d-flex align-items-center">
         {NUMBER_REGEX.test(props.value) ? <Icon className="text-success mr-1" src={Check} /> : <Icon className="mr-1 text-light-700" src={Remove} />}
         {formatMessage(messages['one.number'])}
       </span>
-      <span id="characters-check" className="d-flex position-relative align-content-start">
+      <span id="characters-check" className="d-flex align-items-center">
         {props.value.length >= 8 ? <Icon className="text-success mr-1" src={Check} /> : <Icon className="mr-1 text-light-700" src={Remove} />}
         {formatMessage(messages['eight.characters'])}
       </span>


### PR DESCRIPTION
Password tooltip should use an extra small font size of 12px.

[VAN-577](https://2u-internal.atlassian.net/browse/VAN-577)

**Before**

<img width="1287" alt="Screen Shot 2022-06-27 at 4 14 34 PM" src="https://user-images.githubusercontent.com/52817156/175949624-da83abf0-ddc4-49f5-b647-078ed7a15ccb.png">

**After**

<img width="1156" alt="Screen Shot 2022-06-27 at 4 15 46 PM" src="https://user-images.githubusercontent.com/52817156/175949671-ee126df6-592f-4da4-bc16-7f3cb1bfefdc.png">
