### PR TITLE
fix: password popover rendering issue [VAN-585]

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -300,6 +300,7 @@ select.form-control {
   opacity: 1;
   @extend .x-small;
   filter: drop-shadow($elevation-level-2-shadow) drop-shadow($elevation-level-2-shadow) !important;
+  margin-right: 0.2rem;
   .tooltip-inner {
     background: white;
     display: block;

--- a/src/common-components/messages.jsx
+++ b/src/common-components/messages.jsx
@@ -84,17 +84,17 @@ const messages = defineMessages({
   },
   'one.letter': {
     id: 'one.letter',
-    defaultMessage: '1 Letter',
+    defaultMessage: '1 letter',
     description: 'password requirement to have 1 letter',
   },
   'one.number': {
     id: 'one.number',
-    defaultMessage: '1 Number',
+    defaultMessage: '1 number',
     description: 'password requirement to have 1 number',
   },
   'eight.characters': {
     id: 'eight.characters',
-    defaultMessage: '8 Characters',
+    defaultMessage: '8 characters',
     description: 'password requirement to have a minimum of 8 characters',
   },
   'password.sr.only.helping.text': {


### PR DESCRIPTION
Password tooltip arrow was casting shading on-field border making it look disconnected and the letters should be lowercase in the tooltip.

[VAN-585 ](https://2u-internal.atlassian.net/browse/VAN-585)

**Before**

<img width="663" alt="Screen Shot 2022-06-29 at 10 36 15 AM" src="https://user-images.githubusercontent.com/52817156/176359716-0a478bba-b26a-49c9-8b59-9dac56f3665a.png">

**After**

<img width="690" alt="Screen Shot 2022-06-29 at 10 35 50 AM" src="https://user-images.githubusercontent.com/52817156/176359739-5aa467a6-3355-44d9-aae9-f6ad641c01a6.png">


