### PR TITLE
feat: add query params to the payload

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -242,6 +242,9 @@ class RegistrationPage extends React.Component {
 
     payload = snakeCaseObject(payload);
     payload.totalRegistrationTime = totalRegistrationTime;
+
+    // add query params to the payload
+    payload = { ...payload, ...this.queryParams };
     this.setState({
       totalRegistrationTime,
     }, () => {

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -85,6 +85,7 @@ describe('RegistrationPage', () => {
       handleInstitutionLogin: jest.fn(),
       institutionLogin: false,
     };
+    window.location = { search: '' };
   });
 
   afterEach(() => {
@@ -128,6 +129,9 @@ describe('RegistrationPage', () => {
     it('should submit form for valid input', () => {
       jest.spyOn(global.Date, 'now').mockImplementation(() => 0);
 
+      delete window.location;
+      window.location = { href: getConfig().BASE_URL, search: '?next=/course/demo-course-url' };
+
       const payload = {
         name: 'John Doe',
         username: 'john_doe',
@@ -137,6 +141,7 @@ describe('RegistrationPage', () => {
         honor_code: true,
         totalRegistrationTime: 0,
         is_authn_mfe: true,
+        next: '/course/demo-course-url',
       };
 
       store.dispatch = jest.fn(store.dispatch);


### PR DESCRIPTION
#### Context:
Users are not enrolled in course when creating an account. If they come to authn from the course about page by clicking enroll button, they should redirect to enrollment view after successfully registering with us. 

The next url is missing in our payload which is required by registration view to generate redirect url:

https://github.com/openedx/edx-platform/blob/af81b3a609d1aa9deb658e130613ac463cb48f2e/common/djangoapps/student/helpers.py#L346

Ticket: https://2u-internal.atlassian.net/browse/VAN-1018