### PR TITLE
feat: remove spellcheck from username

### DIFF
--- a/src/common-components/FormGroup.jsx
+++ b/src/common-components/FormGroup.jsx
@@ -29,6 +29,7 @@ const FormGroup = (props) => {
         aria-invalid={props.errorMessage !== ''}
         className="form-field"
         autoComplete={props.autoComplete}
+        spellCheck={props.spellCheck}
         name={props.name}
         value={props.value}
         onFocus={handleFocus}
@@ -64,41 +65,43 @@ const FormGroup = (props) => {
 
 FormGroup.defaultProps = {
   as: 'input',
-  errorMessage: '',
-  borderClass: '',
   autoComplete: null,
-  readOnly: false,
-  handleBlur: null,
-  handleChange: () => {},
-  handleFocus: null,
-  handleClick: null,
-  helpText: [],
-  options: null,
-  trailingElement: null,
-  type: 'text',
+  borderClass: '',
   children: null,
   className: '',
+  errorMessage: '',
+  handleBlur: null,
+  handleChange: () => {},
+  handleClick: null,
+  handleFocus: null,
+  helpText: [],
+  options: null,
+  readOnly: false,
+  spellCheck: null,
+  trailingElement: null,
+  type: 'text',
 };
 
 FormGroup.propTypes = {
   as: PropTypes.string,
-  errorMessage: PropTypes.string,
-  borderClass: PropTypes.string,
   autoComplete: PropTypes.string,
-  readOnly: PropTypes.bool,
+  borderClass: PropTypes.string,
+  children: PropTypes.element,
+  className: PropTypes.string,
+  errorMessage: PropTypes.string,
   floatingLabel: PropTypes.string.isRequired,
   handleBlur: PropTypes.func,
   handleChange: PropTypes.func,
-  handleFocus: PropTypes.func,
   handleClick: PropTypes.func,
+  handleFocus: PropTypes.func,
   helpText: PropTypes.arrayOf(PropTypes.string),
   name: PropTypes.string.isRequired,
   options: PropTypes.func,
+  readOnly: PropTypes.bool,
+  spellCheck: PropTypes.string,
   trailingElement: PropTypes.element,
   type: PropTypes.string,
   value: PropTypes.string.isRequired,
-  children: PropTypes.element,
-  className: PropTypes.string,
 };
 
 export default FormGroup;

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -711,6 +711,8 @@ class RegistrationPage extends React.Component {
 
             <UsernameField
               name="username"
+              autoComplete="false"
+              spellCheck="false"
               value={this.state.username}
               handleBlur={this.handleOnBlur}
               handleChange={this.handleOnChange}


### PR DESCRIPTION
The username field currently has spellcheck set to default which means that on safari or chrome if you have spellcheck enabled it gives its suggestion on the input field. 

Ticket: https://2u-internal.atlassian.net/browse/VAN-1013