### PR TITLE
fix: warning on password field popover margin

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -300,7 +300,7 @@ select.form-control {
   opacity: 1;
   @extend .x-small;
   filter: drop-shadow($elevation-level-2-shadow) drop-shadow($elevation-level-2-shadow) !important;
-  margin-right: 0.2rem;
+  right: 0.2rem !important;
   .tooltip-inner {
     background: white;
     display: block;
@@ -316,7 +316,7 @@ select.form-control {
   filter: drop-shadow($elevation-level-2-shadow) drop-shadow($elevation-level-2-shadow) !important;
   opacity: 1;
   width: 90%;
-  margin-bottom: 10px;
+  bottom: 10px !important;
   display: flex;
   justify-content: center;
 


### PR DESCRIPTION
This PR fixes the warning that was being raised on the password field popover.

**Before:**

<img width="1672" alt="Screen Shot 2022-08-12 at 11 36 13 AM" src="https://user-images.githubusercontent.com/52817156/184298153-49ef018a-fb05-433a-b8b0-da7f1900d116.png">

**After:**

<img width="1680" alt="Screen Shot 2022-08-12 at 11 33 26 AM" src="https://user-images.githubusercontent.com/52817156/184298222-762d742e-49be-4931-98a7-2c74ed362af4.png">
