### PR TITLE
fix: [VAN-628] Google logo is centrally aligned.

### DIFF
--- a/src/_style.scss
+++ b/src/_style.scss
@@ -172,7 +172,10 @@ $elevation-level-2-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.15);
   background-color: $google-blue;
 
   .icon-image {
-    margin-left: 2px;
+    margin-left: -6px;
+    max-height: 34px;
+    max-width: 34px;
+    height: 34px;
   }
 
   &:hover,


### PR DESCRIPTION
### Fix that SSO button google logo is centrally aligned.

### Before Fix
<img width="257" alt="Screen Shot 2022-08-25 at 9 17 27 PM" src="https://user-images.githubusercontent.com/7627421/186717617-03368894-9d04-4e27-8078-516650073b24.png">

### After Fix
<img width="264" alt="Screen Shot 2022-08-25 at 9 16 54 PM" src="https://user-images.githubusercontent.com/7627421/186717700-fcecb878-78e8-4a8f-a619-29d95f80535e.png">


