### PR TITLE
feat: add basic registration form

### DIFF
--- a/src/common-components/FormGroup.jsx
+++ b/src/common-components/FormGroup.jsx
@@ -37,7 +37,6 @@ const FormGroup = (props) => {
         onClick={handleClick}
         onChange={props.handleChange}
         controlClassName={props.borderClass}
-
         trailingElement={props.trailingElement}
         floatingLabel={props.floatingLabel}
       >

--- a/src/common-components/Logistration.jsx
+++ b/src/common-components/Logistration.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
 
 import { getConfig } from '@edx/frontend-platform';
 import { sendPageEvent, sendTrackEvent } from '@edx/frontend-platform/analytics';
@@ -18,6 +19,7 @@ import { LOGIN_PAGE, REGISTER_PAGE } from '../data/constants';
 import { getTpaHint, updatePathWithQueryParams } from '../data/utils';
 import { LoginPage } from '../login';
 import { RegistrationPage } from '../register';
+import { backupRegistrationForm } from '../register/data/actions';
 import messages from './messages';
 
 const Logistration = (props) => {
@@ -46,6 +48,9 @@ const Logistration = (props) => {
 
   const handleOnSelect = (tabKey) => {
     sendTrackEvent(`edx.bi.${tabKey.replace('/', '')}_form.toggled`, { category: 'user-engagement' });
+    if (tabKey === LOGIN_PAGE) {
+      props.backupRegistrationForm();
+    }
     setKey(tabKey);
   };
 
@@ -95,10 +100,16 @@ const Logistration = (props) => {
 Logistration.propTypes = {
   intl: intlShape.isRequired,
   selectedPage: PropTypes.string,
+  backupRegistrationForm: PropTypes.func.isRequired,
 };
 
 Logistration.defaultProps = {
   selectedPage: REGISTER_PAGE,
 };
 
-export default injectIntl(Logistration);
+export default connect(
+  null,
+  {
+    backupRegistrationForm,
+  },
+)(injectIntl(Logistration));

--- a/src/common-components/PasswordField.jsx
+++ b/src/common-components/PasswordField.jsx
@@ -30,11 +30,11 @@ const PasswordField = (props) => {
   };
 
   const HideButton = (
-    <IconButton onFocus={handleFocus} onBlur={handleBlur} name="passwordValidation" src={VisibilityOff} iconAs={Icon} onClick={setHiddenTrue} size="sm" variant="secondary" alt={formatMessage(messages['hide.password'])} />
+    <IconButton onFocus={handleFocus} onBlur={handleBlur} name="password" src={VisibilityOff} iconAs={Icon} onClick={setHiddenTrue} size="sm" variant="secondary" alt={formatMessage(messages['hide.password'])} />
   );
 
   const ShowButton = (
-    <IconButton onFocus={handleFocus} onBlur={handleBlur} name="passwordValidation" src={Visibility} iconAs={Icon} onClick={setHiddenFalse} size="sm" variant="secondary" alt={formatMessage(messages['show.password'])} />
+    <IconButton onFocus={handleFocus} onBlur={handleBlur} name="password" src={Visibility} iconAs={Icon} onClick={setHiddenFalse} size="sm" variant="secondary" alt={formatMessage(messages['show.password'])} />
   );
   const placement = window.innerWidth < 768 ? 'top' : 'left';
   const tooltip = (

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -30,7 +30,7 @@ export const VALID_EMAIL_REGEX = '(^[-!#$%&\'*+/=?^_`{}|~0-9A-Z]+(\\.[-!#$%&\'*+
                                  + '|\\[(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)(\\.(25[0-5]|2[0-4]\\d|[0-1]?\\d?\\d)){3}\\]$';
 export const LETTER_REGEX = /[a-zA-Z]/;
 export const NUMBER_REGEX = /\d/;
-export const VALID_NAME_REGEX = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi; // eslint-disable-line no-useless-escape
+export const INVALID_NAME_REGEX = /[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)?/gi; // eslint-disable-line no-useless-escape
 
 // Query string parameters that can be passed to LMS to manage
 // things like auto-enrollment upon login and registration.

--- a/src/register/RegistrationFailure.jsx
+++ b/src/register/RegistrationFailure.jsx
@@ -18,6 +18,10 @@ const RegistrationFailureMessage = (props) => {
     windowScrollTo({ left: 0, top: 0, behavior: 'smooth' });
   }, [errorCode, failureCount]);
 
+  if (!errorCode) {
+    return null;
+  }
+
   let errorMessage;
   switch (errorCode) {
     case INTERNAL_SERVER_ERROR:

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -1,1054 +1,417 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 
 import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
-import { sendPageEvent, sendTrackEvent } from '@edx/frontend-platform/analytics';
-import {
-  getCountryList, getLocale, injectIntl, intlShape,
-} from '@edx/frontend-platform/i18n';
-import {
-  Alert, Form, Icon, StatefulButton,
-} from '@edx/paragon';
-import { Close, Error } from '@edx/paragon/icons';
-import PropTypes, { string } from 'prop-types';
+import { sendPageEvent } from '@edx/frontend-platform/analytics';
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Form, StatefulButton } from '@edx/paragon';
+import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
-import Skeleton from 'react-loading-skeleton';
 
+import { FormGroup, PasswordField } from '../common-components';
 import {
-  FormGroup, InstitutionLogistration, PasswordField, RedirectLogistration,
-  RenderInstitutionButton, SocialAuthProviders, ThirdPartyAuthAlert,
-} from '../common-components';
-import { getThirdPartyAuthContext } from '../common-components/data/actions';
-import {
-  extendedProfileSelector,
-  fieldDescriptionSelector,
-  optionalFieldsSelector,
-  thirdPartyAuthContextSelector,
-} from '../common-components/data/selectors';
-import EnterpriseSSO from '../common-components/EnterpriseSSO';
-import {
-  DEFAULT_STATE, LETTER_REGEX, NUMBER_REGEX, PENDING_STATE, REGISTER_PAGE, VALID_EMAIL_REGEX, VALID_NAME_REGEX,
+  DEFAULT_STATE,
+  INVALID_NAME_REGEX, LETTER_REGEX, NUMBER_REGEX, VALID_EMAIL_REGEX,
 } from '../data/constants';
 import {
-  getAllPossibleQueryParam, getTpaHint, getTpaProvider, setCookie, setSurveyCookie,
-} from '../data/utils';
-import FormFieldRenderer from '../field-renderer';
-import CountryDropdown from './CountryDropdown';
-import {
+  backupRegistrationFormBegin,
   clearUsernameSuggestions,
   fetchRealtimeValidations,
   registerNewUser,
-  resetRegistrationForm,
-  setRegistrationFormData,
 } from './data/actions';
-import {
-  COMMON_EMAIL_PROVIDERS, DEFAULT_SERVICE_PROVIDER_DOMAINS, DEFAULT_TOP_LEVEL_DOMAINS, FIELDS, FORM_SUBMISSION_ERROR,
-} from './data/constants';
-import {
-  registrationErrorSelector,
-  registrationFormDataSelector,
-  registrationRequestSelector,
-  usernameSuggestionsSelector,
-  validationsSelector,
-} from './data/selectors';
-import HonorCode from './HonorCode';
+import { FORM_SUBMISSION_ERROR } from './data/constants';
+import { registrationErrorSelector, validationsSelector } from './data/selectors';
 import messages from './messages';
 import RegistrationFailure from './RegistrationFailure';
-import TermsOfService from './TermsOfService';
-import UsernameField from './UsernameField';
-import { getLevenshteinSuggestion, getSuggestionForInvalidEmail } from './utils';
+import { EmailField, UsernameField } from './registrationFields';
+import { getSuggestionForInvalidEmail, validateEmailAddress } from './utils';
 
-class RegistrationPage extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-    sendPageEvent('login_and_registration', 'register');
-    this.handleOnClose = this.handleOnClose.bind(this);
+const emailRegex = new RegExp(VALID_EMAIL_REGEX, 'i');
+const urlRegex = new RegExp(INVALID_NAME_REGEX);
 
-    this.queryParams = getAllPossibleQueryParam();
-    // TODO: Once we have tested it and ready for openedX we can remove this flag and make the code
-    // permanent part of Authn and remove extra code
-    this.showDynamicRegistrationFields = getConfig().ENABLE_DYNAMIC_REGISTRATION_FIELDS;
-    this.tpaHint = getTpaHint();
-    const { registrationFormData } = this.props;
-    this.state = {
-      country: '',
-      email: registrationFormData.email,
-      name: registrationFormData.name,
-      password: registrationFormData.password,
-      username: registrationFormData.username,
-      marketingOptIn: registrationFormData.marketingOptIn,
-      errors: {
-        email: registrationFormData.errors.email,
-        name: registrationFormData.errors.name,
-        username: registrationFormData.errors.username,
-        password: registrationFormData.errors.password,
-        country: '',
-      },
-      emailFieldBorderClass: registrationFormData.emailFieldBorderClass,
-      emailErrorSuggestion: registrationFormData.emailErrorSuggestion,
-      emailWarningSuggestion: registrationFormData.emailWarningSuggestion,
-      errorCode: null,
-      failureCount: 0,
-      startTime: Date.now(),
-      totalRegistrationTime: 0,
-      readOnly: true,
-      validatePassword: false,
-      values: {},
-      focusedField: '',
-    };
-  }
+const RegistrationPage = (props) => {
+  const {
+    backedUpFormData,
+    backendValidations,
+    backupFormState,
+    intl,
+    registrationErrorCode,
+    resetUsernameSuggestions,
+    shouldBackupState,
+    submitState,
+    usernameSuggestions,
+    validationApiRateLimited,
+    validateFromBackend,
+  } = props;
 
-  componentDidMount() {
-    const payload = { ...this.queryParams };
-    window.optimizely = window.optimizely || [];
-    window.optimizely.push({
-      type: 'page',
-      pageName: 'authn_registration_page',
-      isActive: true,
-    });
+  const [formFields, setFormFields] = useState({ ...backedUpFormData.formFields });
+  const [errors, setErrors] = useState({ ...backedUpFormData.errors });
+  const [emailSuggestion, setEmailSuggestion] = useState({ ...backedUpFormData.emailSuggestion });
 
-    if (payload.save_for_later === 'true') {
-      sendTrackEvent('edx.bi.user.saveforlater.course.enroll.clicked', { category: 'save-for-later' });
+  const [errorCode, setErrorCode] = useState({ type: '', count: 0 });
+  const [formStartTime, setFormStartTime] = useState(null);
+  const [focusedField, setFocusedField] = useState(null);
+
+  useEffect(() => {
+    if (!formStartTime) {
+      sendPageEvent('login_and_registration', 'register');
+      setFormStartTime(Date.now());
     }
+  }, [formStartTime]);
 
-    if (this.tpaHint) {
-      payload.tpa_hint = this.tpaHint;
-    }
-    payload.is_register_page = true;
-    this.props.resetRegistrationForm();
-    this.props.getThirdPartyAuthContext(payload);
-  }
-
-  shouldComponentUpdate(nextProps) {
-    if (nextProps.registrationFormData && this.props.registrationFormData !== nextProps.registrationFormData) {
-      // Ensuring browser's autofill user credentials get filled and their state persists in the redux store.
-      const nextState = {
-        username: nextProps.registrationFormData.username || this.state.username,
-        password: nextProps.registrationFormData.password || this.state.password,
-      };
-
-      // do not set focused field's value from redux store to retain entered data in focused field\
-      const { focusedField } = this.state;
-      const { [focusedField]: _, ...registrationData } = { ...nextProps.registrationFormData, ...nextState };
-      this.setState({
-        ...registrationData,
+  /**
+   * Backup the registration form in redux when register page is toggled.
+   */
+  useEffect(() => {
+    if (shouldBackupState) {
+      backupFormState({
+        formFields: { ...formFields }, errors: { ...errors }, emailSuggestion: { ...emailSuggestion },
       });
     }
+  }, [shouldBackupState, formFields, errors, emailSuggestion, backupFormState]);
 
-    if (this.props.usernameSuggestions.length > 0 && this.state.username === '') {
-      this.props.setRegistrationFormData({
-        username: ' ',
-      });
-      return false;
+  useEffect(() => {
+    if (backendValidations) {
+      setErrors(prevErrors => ({ ...prevErrors, ...backendValidations }));
     }
+  }, [backendValidations]);
 
-    if (this.props.validationDecisions !== nextProps.validationDecisions) {
-      if (nextProps.validationDecisions) {
-        const state = {};
-        const errors = { ...this.state.errors, ...nextProps.validationDecisions };
-        let validatePassword = false;
+  useEffect(() => {
+    if (registrationErrorCode) {
+      setErrorCode(prevState => ({ type: registrationErrorCode, count: prevState.count + 1 }));
+    }
+  }, [registrationErrorCode]);
 
-        if (errors.password) {
-          validatePassword = true;
+  /**
+   * We need to remove the placeholder from the field, adding a space will do that.
+   * This is needed because we are placing the username suggestions on top of the field.
+   */
+  useEffect(() => {
+    if (usernameSuggestions.length && !formFields.username) {
+      setFormFields({ ...formFields, username: ' ' });
+    }
+  }, [usernameSuggestions, formFields]);
+
+  const validateInput = (fieldName, value, payload, shouldValidateFromBackend, setError = true) => {
+    let fieldError = '';
+
+    switch (fieldName) {
+      case 'name':
+        if (!value.trim()) {
+          fieldError = intl.formatMessage(messages['empty.name.field.error']);
+        } else if (value && value.match(urlRegex)) {
+          fieldError = intl.formatMessage(messages['name.validation.message']);
+        } else if (value && !payload.username.trim() && shouldValidateFromBackend) {
+          validateFromBackend(payload);
         }
-
-        if (nextProps.registrationErrorCode) {
-          state.errorCode = nextProps.registrationErrorCode;
+        break;
+      case 'email':
+        if (!value) {
+          fieldError = intl.formatMessage(messages['empty.email.field.error']);
+        } else if (value.length <= 2) {
+          fieldError = intl.formatMessage(messages['email.invalid.format.error']);
+        } else {
+          const [username, domainName] = value.split('@');
+          // Check if email address is invalid. If we have a suggestion for invalid email
+          // provide that along with the error message.
+          if (!emailRegex.test(value)) {
+            fieldError = intl.formatMessage(messages['email.invalid.format.error']);
+            setEmailSuggestion({
+              suggestion: getSuggestionForInvalidEmail(domainName, username),
+              type: 'error',
+            });
+          } else {
+            const response = validateEmailAddress(value, username, domainName);
+            if (response.hasError) {
+              fieldError = intl.formatMessage(messages['email.invalid.format.error']);
+              delete response.hasError;
+            } else if (shouldValidateFromBackend) {
+              validateFromBackend(payload);
+            }
+            setEmailSuggestion({ ...response });
+          }
         }
-
-        let {
-          suggestedTldMessage,
-          suggestedTopLevelDomain,
-          suggestedSldMessage,
-          suggestedServiceLevelDomain,
-        } = this.state;
-
-        if (errors.email) {
-          suggestedTldMessage = '';
-          suggestedTopLevelDomain = '';
-          suggestedSldMessage = '';
-          suggestedServiceLevelDomain = '';
+        break;
+      case 'username':
+        if (!value || value.length <= 1 || value.length > 30) {
+          fieldError = intl.formatMessage(messages['username.validation.message']);
+        } else if (!value.match(/^[a-zA-Z0-9_-]*$/i)) {
+          fieldError = intl.formatMessage(messages['username.format.validation.message']);
+        } else if (shouldValidateFromBackend) {
+          validateFromBackend(payload);
         }
-
-        this.setState({
-          ...state,
-          suggestedTldMessage,
-          suggestedTopLevelDomain,
-          suggestedSldMessage,
-          suggestedServiceLevelDomain,
-          validatePassword,
-        });
-
-        this.props.setRegistrationFormData({
-          errors,
-        }, true);
-      }
-      return false;
+        break;
+      case 'password':
+        if (!value || !LETTER_REGEX.test(value) || !NUMBER_REGEX.test(value) || value.length < 8) {
+          fieldError = intl.formatMessage(messages['password.validation.message']);
+        } else if (shouldValidateFromBackend) {
+          validateFromBackend(payload);
+        }
+        break;
+      default:
+        break;
     }
-
-    if (this.props.thirdPartyAuthContext.pipelineUserDetails !== nextProps.thirdPartyAuthContext.pipelineUserDetails) {
-      const { pipelineUserDetails } = nextProps.thirdPartyAuthContext;
-      const { registrationFormData } = this.props;
-
-      // Added a conditional errors check to not fall back on pipelines data when a user explicitly edits the form.
-      this.props.setRegistrationFormData({
-        name: registrationFormData.errors.name ? registrationFormData.name
-          : (registrationFormData.name || pipelineUserDetails.name || ''),
-        email: registrationFormData.errors.email ? registrationFormData.email
-          : (registrationFormData.email || pipelineUserDetails.email || ''),
-        username: registrationFormData.errors.username ? registrationFormData.username
-          : (registrationFormData.username || pipelineUserDetails.username || ''),
-        country: registrationFormData.country || nextProps.thirdPartyAuthContext.countryCode,
-      });
-      return false;
+    if (setError) {
+      setErrors({ ...errors, [fieldName]: fieldError });
     }
-
-    if (this.props.thirdPartyAuthContext.countryCode !== nextProps.thirdPartyAuthContext.countryCode) {
-      this.props.setRegistrationFormData({
-        country: this.props.registrationFormData.country || nextProps.thirdPartyAuthContext.countryCode,
-      });
-      return false;
-    }
-
-    return true;
-  }
-
-  onChangeHandler = (e) => {
-    const { name, value, checked } = e.target;
-    const { errors, values } = this.state;
-    if (e.target.type === 'checkbox') {
-      errors[name] = '';
-      values[name] = checked;
-    } else {
-      values[name] = value;
-    }
-    const state = { errors, values };
-    this.setState({ ...state });
+    return fieldError;
   };
 
-  handleSubmit = (e) => {
-    e.preventDefault();
+  const isFormValid = (payload, focusedFieldError) => {
+    const fieldErrors = { ...errors };
+    let isValid = !focusedFieldError;
+    Object.keys(payload).forEach(key => {
+      if (!payload[key]) {
+        fieldErrors[key] = intl.formatMessage(messages[`empty.${key}.field.error`]);
+      }
+      if (fieldErrors[key]) {
+        isValid = false;
+      }
+    });
+    if (focusedField) {
+      fieldErrors[focusedField] = focusedFieldError;
+    }
+    setErrors({ ...fieldErrors });
+    return isValid;
+  };
 
-    const { startTime } = this.state;
-    const totalRegistrationTime = (Date.now() - startTime) / 1000;
-    const dynamicFieldErrorMessages = {};
+  const handleSuggestionClick = (event, fieldName, suggestion = '') => {
+    event.preventDefault();
+    setErrors({ ...errors, [fieldName]: '' });
+    switch (fieldName) {
+      case 'email':
+        setFormFields({ ...formFields, email: emailSuggestion.suggestion });
+        setEmailSuggestion({ suggestion: '', type: '' });
+        break;
+      case 'username':
+        setFormFields({ ...formFields, username: suggestion });
+        resetUsernameSuggestions();
+        break;
+      default:
+        break;
+    }
+  };
 
-    let payload = {
-      name: this.state.name,
-      username: this.state.username,
-      email: this.state.email,
-      is_authn_mfe: true,
+  const handleEmailSuggestionClosed = () => setEmailSuggestion({ suggestion: '', type: '' });
+  const handleUsernameSuggestionClosed = () => resetUsernameSuggestions();
+
+  const handleOnChange = (event) => {
+    const value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
+
+    if (!(event.target.name === 'username' && value.length > 30)) {
+      setFormFields({ ...formFields, [event.target.name]: value });
+    }
+  };
+
+  const handleOnBlur = (event) => {
+    const { name, value } = event.target;
+    const payload = {
+      name: formFields.name,
+      email: formFields.email,
+      username: formFields.username,
+      password: formFields.password,
+      form_field_key: name,
     };
 
-    if (this.props.thirdPartyAuthContext.currentProvider) {
-      payload.social_auth_provider = this.props.thirdPartyAuthContext.currentProvider;
-    } else {
-      payload.password = this.state.password;
-    }
+    setFocusedField(null);
+    validateInput(name, name === 'password' ? formFields.password : value, payload, !validationApiRateLimited);
+  };
 
-    if (this.showDynamicRegistrationFields) {
-      payload.extendedProfile = [];
-      Object.keys(this.props.fieldDescriptions).forEach((fieldName) => {
-        if (this.props.extendedProfile.includes(fieldName)) {
-          payload.extendedProfile.push({ fieldName, fieldValue: this.state.values[fieldName] });
-        } else {
-          payload[fieldName] = this.state.values[fieldName];
-        }
-        dynamicFieldErrorMessages[fieldName] = this.props.fieldDescriptions[fieldName].error_message;
-      });
-      if (
-        this.props.fieldDescriptions[FIELDS.HONOR_CODE]
-        && this.props.fieldDescriptions[FIELDS.HONOR_CODE].type === 'tos_and_honor_code'
-      ) {
-        payload[FIELDS.HONOR_CODE] = true;
+  const handleOnFocus = (event) => {
+    const { name, value } = event.target;
+    const fieldErrors = { ...errors };
+    fieldErrors[name] = '';
+    setErrors(fieldErrors);
+    // Since we are removing the form errors from the focused field, we will
+    // need to rerun the validation for focused field on form submission.
+    setFocusedField(name);
+
+    if (name === 'username') {
+      resetUsernameSuggestions();
+      // If we added a space character to username field to display the suggestion
+      // remove it before user enters the input. This is to ensure user doesn't
+      // have a space prefixed to the username.
+      if (value === ' ') {
+        setFormFields({ ...formFields, [name]: '' });
       }
-    } else {
-      payload.country = this.state.country;
-      payload.honor_code = true;
     }
+  };
 
-    if (!this.isFormValid(payload, dynamicFieldErrorMessages)) {
-      this.setState(prevState => ({
-        errorCode: FORM_SUBMISSION_ERROR,
-        failureCount: prevState.failureCount + 1,
-      }));
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    const totalRegistrationTime = (Date.now() - formStartTime) / 1000;
+    let payload = { ...formFields };
+
+    const fieldError = focusedField ? (
+      validateInput(focusedField, formFields[focusedField], payload, false, false)
+    ) : '';
+
+    if (!isFormValid(payload, fieldError)) {
+      setErrorCode(prevState => ({ type: FORM_SUBMISSION_ERROR, count: prevState.count + 1 }));
       return;
-    }
-
-    if (getConfig().MARKETING_EMAILS_OPT_IN) {
-      payload.marketing_emails_opt_in = this.state.marketingOptIn;
     }
 
     payload = snakeCaseObject(payload);
     payload.totalRegistrationTime = totalRegistrationTime;
 
     // add query params to the payload
-    payload = { ...payload, ...this.queryParams };
-    this.setState({
-      totalRegistrationTime,
-    }, () => {
-      this.props.registerNewUser(payload);
-    });
-  }
+    // payload = { ...payload, ...this.queryParams };
+    props.registerNewUser(payload);
+  };
 
-  handleOnBlur = (e) => {
-    let { name, value } = e.target;
-    this.setState({
-      focusedField: '',
-    });
-
-    if (name === 'passwordValidation') {
-      name = 'password';
-      value = this.state.password;
-    }
-    const payload = {
-      is_authn_mfe: true,
-      form_field_key: name,
-      email: this.state.email,
-      username: this.state.username,
-      password: this.state.password,
-      name: this.state.name,
-      honor_code: true,
-      country: this.state.country,
-    };
-    this.validateInput(name, value, payload);
-  }
-
-  handleOnChange = (e) => {
-    if (!(e.target.name === 'username' && e.target.value.length > 30)) {
-      this.setState({
-        [e.target.name]: e.target.value,
-      });
-    }
-  }
-
-  handleCountryChange = (value) => {
-    // TODO: Remove this function once error message is passed as props from
-    // RegistrationPage to CountryDropdown component.
-    if (this.props.registrationFormData.errors.country) {
-      this.props.setRegistrationFormData({
-        country: value,
-        errors: {
-          ...this.props.registrationFormData.errors,
-          country: '',
-        },
-      });
-    } else {
-      this.props.setRegistrationFormData({
-        country: value,
-      });
-    }
-  }
-
-  handleOnFocus = (e) => {
-    const fieldName = e.target.name;
-    this.setState({
-      focusedField: fieldName,
-    });
-    const { errors } = this.state;
-    errors[fieldName] = '';
-    if (fieldName === 'username') {
-      this.props.clearUsernameSuggestions();
-    }
-    if (fieldName === 'country') {
-      this.setState({ readOnly: false });
-    }
-    if (fieldName === 'passwordValidation') {
-      errors.password = '';
-    }
-
-    this.props.setRegistrationFormData({
-      errors,
-    });
-  }
-
-  handleSuggestionClick = (e, suggestion) => {
-    const { errors } = this.state;
-    if (e.target.name === 'username') {
-      errors.username = '';
-      this.props.setRegistrationFormData({
-        username: suggestion,
-        errors,
-      });
-      this.props.clearUsernameSuggestions();
-    } else if (e.target.name === 'email') {
-      e.preventDefault();
-      errors.email = '';
-      this.props.setRegistrationFormData({
-        email: suggestion,
-        emailErrorSuggestion: null,
-        emailWarningSuggestion: null,
-        emailFieldBorderClass: '',
-        errors,
-      });
-    }
-  }
-
-  handleUsernameSuggestionClose = () => {
-    this.props.setRegistrationFormData({
-      username: '',
-    });
-    this.props.clearUsernameSuggestions();
-  }
-
-  validateDynamicFields = (e) => {
-    const { intl } = this.props;
-    const { errors } = this.state;
-    const { name, value } = e.target;
-    if (!value.trim()) {
-      errors[name] = this.props.fieldDescriptions[name].error_message;
-    }
-    if (name === 'confirm_email' && value.length > 0 && this.state.email && value !== this.state.email) {
-      errors.confirm_email = intl.formatMessage(messages['email.do.not.match']);
-    }
-    this.setState({ errors });
-  }
-
-  isFormValid(payload, dynamicFieldError) {
-    const { errors } = this.state;
-    let isValid = true;
-    Object.keys(payload).forEach(key => {
-      if (!payload[key]) {
-        errors[key] = (key in dynamicFieldError) ? dynamicFieldError[key] : this.props.intl.formatMessage(messages[`empty.${key}.field.error`]);
-      }
-      // Mark form invalid, if there was already a validation error for this key or we added empty field error
-      if (errors[key]) {
-        isValid = false;
-      }
-    });
-
-    const state = { ...payload, errors };
-    this.props.setRegistrationFormData({
-      ...state,
-    });
-    return isValid;
-  }
-
-  validateInput(fieldName, value, payload) {
-    let state = {};
-    const { errors } = this.state;
-    const { intl, statusCode } = this.props;
-    const emailRegex = new RegExp(VALID_EMAIL_REGEX, 'i');
-    const urlRegex = new RegExp(VALID_NAME_REGEX);
-
-    switch (fieldName) {
-      case 'email':
-        if (!value) {
-          errors.email = intl.formatMessage(messages['empty.email.field.error']);
-        } else if (value.length <= 2) {
-          errors.email = intl.formatMessage(messages['email.invalid.format.error']);
-        } else {
-          let emailWarningSuggestion = null;
-          let emailErrorSuggestion = null;
-
-          const [username, domainName] = value.split('@');
-
-          // Check if email address is invalid. If we have a suggestion for invalid email provide that along with
-          // error message.
-          if (!emailRegex.test(value)) {
-            errors.email = intl.formatMessage(messages['email.invalid.format.error']);
-            emailErrorSuggestion = getSuggestionForInvalidEmail(domainName, username);
-          } else {
-            let suggestion = null;
-            const hasMultipleSubdomains = value.match(/\./g).length > 1;
-            const [serviceLevelDomain, topLevelDomain] = domainName.split('.');
-            const tldSuggestion = !DEFAULT_TOP_LEVEL_DOMAINS.includes(topLevelDomain);
-            const serviceSuggestion = getLevenshteinSuggestion(serviceLevelDomain, DEFAULT_SERVICE_PROVIDER_DOMAINS, 2);
-
-            if (DEFAULT_SERVICE_PROVIDER_DOMAINS.includes(serviceSuggestion || serviceLevelDomain)) {
-              suggestion = `${username}@${serviceSuggestion || serviceLevelDomain}.com`;
-            }
-
-            if (!hasMultipleSubdomains && tldSuggestion) {
-              emailErrorSuggestion = suggestion;
-            } else if (serviceSuggestion) {
-              emailWarningSuggestion = suggestion;
-            } else {
-              suggestion = getLevenshteinSuggestion(domainName, COMMON_EMAIL_PROVIDERS, 3);
-              if (suggestion) {
-                emailWarningSuggestion = `${username}@${suggestion}`;
-              }
-            }
-
-            if (!hasMultipleSubdomains && tldSuggestion) {
-              errors.email = intl.formatMessage(messages['email.invalid.format.error']);
-            } else if (payload && statusCode !== 403) {
-              this.props.fetchRealtimeValidations(payload);
-            } else {
-              errors.email = '';
-            }
-            if (this.state.values && this.state.values.confirm_email && value !== this.state.values.confirm_email) {
-              errors.confirm_email = intl.formatMessage(messages['email.do.not.match']);
-            }
-          }
-          state = {
-            emailWarningSuggestion,
-            emailErrorSuggestion,
-            emailFieldBorderClass: emailWarningSuggestion ? 'yellow-border' : null,
-          };
-        }
-        break;
-      case 'name':
-        if (!value.trim()) {
-          errors.name = intl.formatMessage(messages['empty.name.field.error']);
-        } else if (value && value.match(urlRegex)) {
-          errors.name = intl.formatMessage(messages['name.validation.message']);
-        } else {
-          errors.name = '';
-        }
-
-        if (!this.state.username.trim() && value) {
-          // fetch username suggestions based on the full name
-          this.props.fetchRealtimeValidations(payload);
-        }
-        break;
-      case 'username':
-        if (value === ' ' && this.props.usernameSuggestions.length > 0) {
-          errors.username = '';
-          break;
-        }
-        if (!value || value.length <= 1 || value.length > 30) {
-          errors.username = intl.formatMessage(messages['username.validation.message']);
-        } else if (!value.match(/^[a-zA-Z0-9_-]*$/i)) {
-          errors.username = intl.formatMessage(messages['username.format.validation.message']);
-        } else if (payload && statusCode !== 403) {
-          this.props.fetchRealtimeValidations(payload);
-        } else {
-          errors.username = '';
-        }
-
-        if (this.state.validatePassword) {
-          this.props.fetchRealtimeValidations({ ...payload, form_field_key: 'password' });
-        }
-        break;
-      case 'password':
-        errors.password = '';
-        if (!value || !LETTER_REGEX.test(value) || !NUMBER_REGEX.test(value) || value.length < 8) {
-          errors.password = intl.formatMessage(messages['password.validation.message']);
-        } else if (payload && statusCode !== 403) {
-          this.props.fetchRealtimeValidations(payload);
-        }
-        break;
-      case 'country':
-        if (!value.trim()) {
-          errors.country = intl.formatMessage(messages['empty.country.field.error']);
-        } else {
-          errors.country = '';
-        }
-        break;
-      default:
-        break;
-    }
-
-    if (fieldName !== 'country') {
-      state = {
-        ...state,
-        [fieldName]: value,
-      };
-    }
-
-    this.props.setRegistrationFormData({
-      ...state,
-      errors,
-    });
-
-    return errors;
-  }
-
-  handleOnClose() {
-    this.props.setRegistrationFormData({
-      emailErrorSuggestion: null,
-    });
-  }
-
-  renderEmailFeedback() {
-    if (this.state.emailErrorSuggestion) {
-      return (
-        <Alert variant="danger" className="email-error-alert" icon={Error}>
-          <span className="alert-text">
-            {this.props.intl.formatMessage(messages['did.you.mean.alert.text'])}{' '}
-            <Alert.Link
-              href="#"
-              name="email"
-              onClick={e => { this.handleSuggestionClick(e, this.state.emailErrorSuggestion); }}
-            >
-              {this.state.emailErrorSuggestion}
-            </Alert.Link>?<Icon src={Close} className="alert-close" onClick={this.handleOnClose} tabIndex="0" />
-          </span>
-        </Alert>
-      );
-    }
-    if (this.state.emailWarningSuggestion) {
-      return (
-        <span className="small">
-          {this.props.intl.formatMessage(messages['did.you.mean.alert.text'])}:{' '}
-          <Alert.Link
-            href="#"
+  return (
+    <>
+      <Helmet>
+        <title>{intl.formatMessage(messages['register.page.title'], { siteName: getConfig().SITE_NAME })}</title>
+      </Helmet>
+      <div className="mw-xs mt-3">
+        <RegistrationFailure
+          errorCode={errorCode.type}
+          failureCount={errorCode.count}
+        />
+        <Form id="registration-form" name="registration-form">
+          <FormGroup
+            name="name"
+            value={formFields.name}
+            handleChange={handleOnChange}
+            handleBlur={handleOnBlur}
+            handleFocus={handleOnFocus}
+            errorMessage={errors.name}
+            helpText={[intl.formatMessage(messages['help.text.name'])]}
+            floatingLabel={intl.formatMessage(messages['registration.fullname.label'])}
+          />
+          <EmailField
             name="email"
-            className="email-warning-alert-link"
-            onClick={e => { this.handleSuggestionClick(e, this.state.emailWarningSuggestion); }}
-          >
-            {this.state.emailWarningSuggestion}
-          </Alert.Link>?
-        </span>
-      );
-    }
-
-    return null;
-  }
-
-  renderThirdPartyAuth(providers, secondaryProviders, currentProvider, thirdPartyAuthApiStatus, intl) {
-    const isInstitutionAuthActive = !!secondaryProviders.length && !currentProvider;
-    const isSocialAuthActive = !!providers.length && !currentProvider;
-    const isEnterpriseLoginDisabled = getConfig().DISABLE_ENTERPRISE_LOGIN;
-
-    return (
-      <>
-        {((isEnterpriseLoginDisabled && isInstitutionAuthActive) || isSocialAuthActive) && (
-          <div className="mt-4 mb-3 h4">
-            {intl.formatMessage(messages['registration.other.options.heading'])}
-          </div>
-        )}
-
-        {thirdPartyAuthApiStatus === PENDING_STATE ? (
-          <Skeleton className="tpa-skeleton" height={36} count={2} />
-        ) : (
-          <>
-            {(isEnterpriseLoginDisabled && isInstitutionAuthActive) && (
-              <RenderInstitutionButton
-                onSubmitHandler={this.props.handleInstitutionLogin}
-                buttonTitle={intl.formatMessage(messages['register.institution.login.button'])}
-              />
-            )}
-            {isSocialAuthActive && (
-              <div className="row m-0">
-                <SocialAuthProviders socialAuthProviders={providers} referrer={REGISTER_PAGE} />
-              </div>
-            )}
-          </>
-        )}
-      </>
-    );
-  }
-
-  renderForm(currentProvider,
-    providers,
-    secondaryProviders,
-    thirdPartyAuthApiStatus,
-    finishAuthUrl,
-    submitState,
-    intl) {
-    if (this.props.institutionLogin) {
-      return (
-        <InstitutionLogistration
-          secondaryProviders={this.props.thirdPartyAuthContext.secondaryProviders}
-          headingTitle={intl.formatMessage(messages['register.institution.login.page.title'])}
-        />
-      );
-    }
-
-    if (this.props.registrationResult.success) {
-      setSurveyCookie('register');
-      setCookie(getConfig().REGISTER_CONVERSION_COOKIE_NAME, true);
-      setCookie('authn-returning-user');
-
-      // Fire optimizely events
-      window.optimizely = window.optimizely || [];
-      window.optimizely.push({
-        type: 'event',
-        eventName: 'authn-register-conversion',
-        tags: {
-          value: this.state.totalRegistrationTime,
-        },
-      });
-    }
-
-    const honorCode = [];
-    const formFields = this.showDynamicRegistrationFields ? (
-      Object.keys(this.props.fieldDescriptions).map((fieldName) => {
-        const fieldData = this.props.fieldDescriptions[fieldName];
-        switch (fieldData.name) {
-          case FIELDS.COUNTRY:
-            return (
-              <span key={fieldData.name}>
-                <CountryDropdown
-                  name="country"
-                  floatingLabel={intl.formatMessage(messages['registration.country.label'])}
-                  options={getCountryList(getLocale())}
-                  valueKey="code"
-                  displayValueKey="name"
-                  value={this.state.values[fieldData.name]}
-                  handleBlur={this.handleOnBlur}
-                  handleFocus={this.handleOnFocus}
-                  errorMessage={intl.formatMessage(messages['empty.country.field.error'])}
-                  handleChange={
-                    (value) => this.setState(prevState => ({ values: { ...prevState.values, country: value } }))
-                  }
-                  errorCode={this.state.errorCode}
-                  readOnly={this.state.readOnly}
-                />
-              </span>
-            );
-          case FIELDS.HONOR_CODE:
-            honorCode.push(
-              <span key={fieldData.name}>
-                <HonorCode
-                  fieldType={fieldData.type}
-                  value={this.state.values[fieldData.name]}
-                  onChangeHandler={this.onChangeHandler}
-                  errorMessage={this.state.errors[fieldData.name]}
-                />
-              </span>,
-            );
-            return null;
-          case FIELDS.TERMS_OF_SERVICE:
-            honorCode.push(
-              <span key={fieldData.name}>
-                <TermsOfService
-                  value={this.state.values[fieldData.name]}
-                  onChangeHandler={this.onChangeHandler}
-                  errorMessage={this.state.errors[fieldData.name]}
-                />
-              </span>,
-            );
-            return null;
-          default:
-            return (
-              <span key={fieldData.name}>
-                <FormFieldRenderer
-                  fieldData={fieldData}
-                  value={this.state.values[fieldData.name]}
-                  onChangeHandler={this.onChangeHandler}
-                  handleBlur={this.validateDynamicFields}
-                  handleFocus={this.handleOnFocus}
-                  errorMessage={this.state.errors[fieldData.name]}
-                  isRequired
-                />
-              </span>
-            );
-        }
-      })
-    ) : null;
-
-    return (
-      <>
-        <Helmet>
-          <title>{intl.formatMessage(messages['register.page.title'],
-            { siteName: getConfig().SITE_NAME })}
-          </title>
-        </Helmet>
-        <RedirectLogistration
-          success={this.props.registrationResult.success}
-          redirectUrl={this.props.registrationResult.redirectUrl}
-          finishAuthUrl={finishAuthUrl}
-          optionalFields={this.props.optionalFields}
-          redirectToWelcomePage={
-            // eslint-disable-next-line no-nested-ternary
-            getConfig().ENABLE_PROGRESSIVE_PROFILING
-              ? (getConfig().ENABLE_DYNAMIC_REGISTRATION_FIELDS
-                ? Object.keys(this.props.optionalFields).length !== 0 : true
-              ) : false
-          }
-        />
-        <div className="mw-xs mt-3">
-          {this.state.errorCode ? (
-            <RegistrationFailure
-              errorCode={this.state.errorCode}
-              failureCount={this.state.failureCount}
-              context={{ provider: currentProvider }}
-            />
-          ) : null}
-          {currentProvider && (
-            <>
-              <ThirdPartyAuthAlert
-                currentProvider={currentProvider}
-                platformName={this.props.thirdPartyAuthContext.platformName}
-                referrer={REGISTER_PAGE}
-              />
-              <h4 className="mt-4 mb-4">{intl.formatMessage(messages['registration.using.tpa.form.heading'])}</h4>
-            </>
-          )}
-          <Form id="registration-form" name="registration-form">
-            <FormGroup
-              name="name"
-              value={this.state.name}
-              handleBlur={this.handleOnBlur}
-              handleChange={this.handleOnChange}
-              handleFocus={this.handleOnFocus}
-              errorMessage={this.state.errors.name}
-              helpText={[intl.formatMessage(messages['help.text.name'])]}
-              floatingLabel={intl.formatMessage(messages['registration.fullname.label'])}
-            />
-            <FormGroup
-              name="email"
-              value={this.state.email}
-              handleBlur={this.handleOnBlur}
-              handleChange={this.handleOnChange}
-              errorMessage={this.state.errors.email}
-              handleFocus={this.handleOnFocus}
-              helpText={[intl.formatMessage(messages['help.text.email'])]}
-              floatingLabel={intl.formatMessage(messages['registration.email.label'])}
-              borderClass={this.state.emailFieldBorderClass}
+            value={formFields.email}
+            handleChange={handleOnChange}
+            handleBlur={handleOnBlur}
+            handleFocus={handleOnFocus}
+            handleSuggestionClick={(e) => handleSuggestionClick(e, 'email')}
+            handleOnClose={handleEmailSuggestionClosed}
+            emailSuggestion={emailSuggestion}
+            errorMessage={errors.email}
+            helpText={[intl.formatMessage(messages['help.text.email'])]}
+            floatingLabel={intl.formatMessage(messages['registration.email.label'])}
+          />
+          <UsernameField
+            name="username"
+            spellCheck="false"
+            value={formFields.username}
+            handleBlur={handleOnBlur}
+            handleChange={handleOnChange}
+            handleFocus={handleOnFocus}
+            handleSuggestionClick={handleSuggestionClick}
+            handleUsernameSuggestionClose={handleUsernameSuggestionClosed}
+            usernameSuggestions={usernameSuggestions}
+            errorMessage={errors.username}
+            helpText={[intl.formatMessage(messages['help.text.username.1']), intl.formatMessage(messages['help.text.username.2'])]}
+            floatingLabel={intl.formatMessage(messages['registration.username.label'])}
+          />
+          <PasswordField
+            name="password"
+            value={formFields.password}
+            handleChange={handleOnChange}
+            handleBlur={handleOnBlur}
+            handleFocus={handleOnFocus}
+            errorMessage={errors.password}
+            floatingLabel={intl.formatMessage(messages['registration.password.label'])}
+          />
+          {(getConfig().MARKETING_EMAILS_OPT_IN)
+          && (
+            <Form.Checkbox
+              name="marketingEmailsOptIn"
+              className="opt-checkbox"
+              checked={formFields.marketingEmailsOptIn}
+              onChange={handleOnChange}
             >
-              {this.renderEmailFeedback()}
-            </FormGroup>
-
-            <UsernameField
-              name="username"
-              spellCheck="false"
-              value={this.state.username}
-              handleBlur={this.handleOnBlur}
-              handleChange={this.handleOnChange}
-              handleFocus={this.handleOnFocus}
-              errorMessage={this.state.errors.username}
-              helpText={[intl.formatMessage(messages['help.text.username.1']), intl.formatMessage(messages['help.text.username.2'])]}
-              floatingLabel={intl.formatMessage(messages['registration.username.label'])}
-              handleSuggestionClick={this.handleSuggestionClick}
-              usernameSuggestions={this.props.usernameSuggestions}
-              handleUsernameSuggestionClose={this.handleUsernameSuggestionClose}
-            />
-
-            {!currentProvider && (
-              <PasswordField
-                name="password"
-                value={this.state.password}
-                handleBlur={this.handleOnBlur}
-                handleChange={this.handleOnChange}
-                handleFocus={this.handleOnFocus}
-                errorMessage={this.state.errors.password}
-                floatingLabel={intl.formatMessage(messages['registration.password.label'])}
-              />
-            )}
-            {!(this.showDynamicRegistrationFields)
-            && (
-              <CountryDropdown
-                name="country"
-                floatingLabel={intl.formatMessage(messages['registration.country.label'])}
-                options={getCountryList(getLocale())}
-                valueKey="code"
-                displayValueKey="name"
-                value={this.state.country}
-                handleBlur={this.handleOnBlur}
-                handleFocus={this.handleOnFocus}
-                errorMessage={intl.formatMessage(messages['empty.country.field.error'])}
-                handleChange={(value) => this.handleCountryChange(value)}
-                errorCode={this.state.errorCode}
-                readOnly={this.state.readOnly}
-              />
-            )}
-            {formFields}
-            {(getConfig().MARKETING_EMAILS_OPT_IN)
-            && (
-              <Form.Checkbox
-                className="opt-checkbox"
-                name="marketing_emails_opt_in"
-                checked={this.state.marketingOptIn}
-                onChange={(e) => this.props.setRegistrationFormData({
-                  marketingOptIn: e.target.checked,
-                })}
-              >
-                {intl.formatMessage(messages['registration.opt.in.label'], { siteName: getConfig().SITE_NAME })}
-              </Form.Checkbox>
-            )}
-            {!(this.showDynamicRegistrationFields) ? (
-              <HonorCode
-                fieldType="tos_and_honor_code"
-              />
-            ) : <div>{honorCode}</div>}
-            <StatefulButton
-              name="register-user"
-              id="register-user"
-              type="submit"
-              variant="brand"
-              className="register-stateful-button-width mt-4 mb-4"
-              state={submitState}
-              labels={{
-                default: intl.formatMessage(messages['create.account.for.free.button']),
-                pending: '',
-              }}
-              onClick={this.handleSubmit}
-              onMouseDown={(e) => e.preventDefault()}
-            />
-            {this.renderThirdPartyAuth(providers,
-              secondaryProviders,
-              currentProvider,
-              thirdPartyAuthApiStatus,
-              intl)}
-          </Form>
-        </div>
-      </>
-    );
-  }
-
-  render() {
-    const { intl, submitState, thirdPartyAuthApiStatus } = this.props;
-    const {
-      currentProvider, finishAuthUrl, providers, secondaryProviders,
-    } = this.props.thirdPartyAuthContext;
-
-    if (this.tpaHint) {
-      if (thirdPartyAuthApiStatus === PENDING_STATE) {
-        return <Skeleton height={36} />;
-      }
-      const { provider, skipHintedLogin } = getTpaProvider(this.tpaHint, providers, secondaryProviders);
-      if (skipHintedLogin) {
-        window.location.href = getConfig().LMS_BASE_URL + provider.registerUrl;
-        return null;
-      }
-      return provider ? (<EnterpriseSSO provider={provider} intl={intl} />)
-        : this.renderForm(
-          currentProvider,
-          providers,
-          secondaryProviders,
-          thirdPartyAuthApiStatus,
-          finishAuthUrl,
-          submitState,
-          intl,
-        );
-    }
-    return this.renderForm(
-      currentProvider,
-      providers,
-      secondaryProviders,
-      thirdPartyAuthApiStatus,
-      finishAuthUrl,
-      submitState,
-      intl,
-    );
-  }
-}
-
-RegistrationPage.defaultProps = {
-  extendedProfile: [],
-  fieldDescriptions: {},
-  optionalFields: {},
-  registrationResult: null,
-  registerNewUser: null,
-  registrationErrorCode: null,
-  submitState: DEFAULT_STATE,
-  thirdPartyAuthApiStatus: 'pending',
-  thirdPartyAuthContext: {
-    currentProvider: null,
-    finishAuthUrl: null,
-    countryCode: null,
-    providers: [],
-    secondaryProviders: [],
-    pipelineUserDetails: null,
-  },
-  registrationFormData: {
-    country: '',
-    email: '',
-    name: '',
-    password: '',
-    username: '',
-    marketingOptIn: true,
-    errors: {
-      email: '',
-      name: '',
-      username: '',
-      password: '',
-      country: '',
-    },
-    emailFieldBorderClass: '',
-    emailErrorSuggestion: null,
-    emailWarningSuggestion: null,
-  },
-  validationDecisions: null,
-  statusCode: null,
-  usernameSuggestions: [],
-};
-
-RegistrationPage.propTypes = {
-  extendedProfile: PropTypes.arrayOf(PropTypes.string),
-  fieldDescriptions: PropTypes.shape({}),
-  optionalFields: PropTypes.shape({}),
-  intl: intlShape.isRequired,
-  getThirdPartyAuthContext: PropTypes.func.isRequired,
-  registerNewUser: PropTypes.func,
-  resetRegistrationForm: PropTypes.func.isRequired,
-  setRegistrationFormData: PropTypes.func.isRequired,
-  registrationResult: PropTypes.shape({
-    redirectUrl: PropTypes.string,
-    success: PropTypes.bool,
-  }),
-  registrationErrorCode: PropTypes.string,
-  submitState: PropTypes.string,
-  thirdPartyAuthApiStatus: PropTypes.string,
-  registrationFormData: PropTypes.shape({
-    country: PropTypes.string,
-    email: PropTypes.string,
-    name: PropTypes.string,
-    password: PropTypes.string,
-    username: PropTypes.string,
-    marketingOptIn: PropTypes.bool,
-    errors: PropTypes.shape({
-      email: PropTypes.string,
-      name: PropTypes.string,
-      username: PropTypes.string,
-      password: PropTypes.string,
-      country: PropTypes.string,
-    }),
-    emailFieldBorderClass: PropTypes.string,
-    emailErrorSuggestion: PropTypes.string,
-    emailWarningSuggestion: PropTypes.string,
-  }),
-  thirdPartyAuthContext: PropTypes.shape({
-    currentProvider: PropTypes.string,
-    platformName: PropTypes.string,
-    providers: PropTypes.array,
-    secondaryProviders: PropTypes.array,
-    finishAuthUrl: PropTypes.string,
-    countryCode: PropTypes.string,
-    pipelineUserDetails: PropTypes.shape({
-      email: PropTypes.string,
-      name: PropTypes.string,
-      firstName: PropTypes.string,
-      lastName: PropTypes.string,
-      username: PropTypes.string,
-    }),
-  }),
-  fetchRealtimeValidations: PropTypes.func.isRequired,
-  validationDecisions: PropTypes.shape({
-    country: PropTypes.string,
-    email: PropTypes.string,
-    name: PropTypes.string,
-    password: PropTypes.string,
-    username: PropTypes.string,
-  }),
-  clearUsernameSuggestions: PropTypes.func.isRequired,
-  statusCode: PropTypes.number,
-  usernameSuggestions: PropTypes.arrayOf(string),
-  institutionLogin: PropTypes.bool.isRequired,
-  handleInstitutionLogin: PropTypes.func.isRequired,
+              {intl.formatMessage(messages['registration.opt.in.label'], { siteName: getConfig().SITE_NAME })}
+            </Form.Checkbox>
+          )}
+          <StatefulButton
+            id="register-user"
+            name="register-user"
+            type="submit"
+            variant="brand"
+            className="register-stateful-button-width mt-4 mb-4"
+            state={submitState}
+            labels={{
+              default: intl.formatMessage(messages['create.account.for.free.button']),
+              pending: '',
+            }}
+            onClick={handleSubmit}
+            onMouseDown={(e) => e.preventDefault()}
+          />
+        </Form>
+      </div>
+    </>
+  );
 };
 
 const mapStateToProps = state => {
-  const registrationResult = registrationRequestSelector(state);
-  const thirdPartyAuthContext = thirdPartyAuthContextSelector(state);
+  const registerPageState = state.register;
   return {
+    backedUpFormData: registerPageState.registrationFormData,
+    backendValidations: validationsSelector(state),
     registrationErrorCode: registrationErrorSelector(state),
-    submitState: state.register.submitState,
-    thirdPartyAuthApiStatus: state.commonComponents.thirdPartyAuthApiStatus,
-    registrationResult,
-    thirdPartyAuthContext,
-    validationDecisions: validationsSelector(state),
-    statusCode: state.register.statusCode,
-    usernameSuggestions: usernameSuggestionsSelector(state),
-    registrationFormData: registrationFormDataSelector(state),
-    fieldDescriptions: fieldDescriptionSelector(state),
-    optionalFields: optionalFieldsSelector(state),
-    extendedProfile: extendedProfileSelector(state),
+    shouldBackupState: registerPageState.shouldBackupState,
+    submitState: registerPageState.submitState,
+    validationApiRateLimited: registerPageState.validationApiRateLimited,
+    usernameSuggestions: registerPageState.usernameSuggestions,
   };
+};
+
+RegistrationPage.propTypes = {
+  backedUpFormData: PropTypes.shape({
+    formFields: PropTypes.shape({}),
+    errors: PropTypes.shape({}),
+    emailSuggestion: PropTypes.shape({}),
+  }),
+  backendValidations: PropTypes.shape({
+    name: PropTypes.string,
+    email: PropTypes.string,
+    username: PropTypes.string,
+    password: PropTypes.string,
+  }),
+  intl: intlShape.isRequired,
+  registrationErrorCode: PropTypes.string,
+  shouldBackupState: PropTypes.bool,
+  submitState: PropTypes.string,
+  validationApiRateLimited: PropTypes.bool,
+  usernameSuggestions: PropTypes.arrayOf(PropTypes.string),
+  // Actions
+  backupFormState: PropTypes.func.isRequired,
+  registerNewUser: PropTypes.func.isRequired,
+  resetUsernameSuggestions: PropTypes.func.isRequired,
+  validateFromBackend: PropTypes.func.isRequired,
+};
+
+RegistrationPage.defaultProps = {
+  backedUpFormData: {
+    formFields: {
+      name: '', email: '', username: '', password: '', marketingEmailsOptIn: true,
+    },
+    errors: {
+      name: '', email: '', username: '', password: '',
+    },
+    emailSuggestion: {
+      suggestion: '', type: '',
+    },
+  },
+  backendValidations: null,
+  registrationErrorCode: '',
+  shouldBackupState: false,
+  submitState: DEFAULT_STATE,
+  validationApiRateLimited: false,
+  usernameSuggestions: [],
 };
 
 export default connect(
   mapStateToProps,
   {
-    clearUsernameSuggestions,
-    getThirdPartyAuthContext,
-    fetchRealtimeValidations,
+    backupFormState: backupRegistrationFormBegin,
+    resetUsernameSuggestions: clearUsernameSuggestions,
+    validateFromBackend: fetchRealtimeValidations,
     registerNewUser,
-    resetRegistrationForm,
-    setRegistrationFormData,
   },
 )(injectIntl(RegistrationPage));

--- a/src/register/data/actions.js
+++ b/src/register/data/actions.js
@@ -1,15 +1,38 @@
 import { AsyncActionType } from '../../data/utils';
 
-export const REGISTER_NEW_USER = new AsyncActionType('REGISTRATION', 'REGISTER_NEW_USER');
+export const BACKUP_REGISTRATION_DATA = new AsyncActionType('REGISTRATION', 'BACKUP_REGISTRATION_DATA');
 export const REGISTER_FORM_VALIDATIONS = new AsyncActionType('REGISTRATION', 'GET_FORM_VALIDATIONS');
-export const REGISTRATION_FORM = new AsyncActionType('REGISTRATION', 'REGISTRATION_FORM');
+export const REGISTER_NEW_USER = new AsyncActionType('REGISTRATION', 'REGISTER_NEW_USER');
 export const REGISTER_CLEAR_USERNAME_SUGGESTIONS = 'REGISTRATION_CLEAR_USERNAME_SUGGESTIONS';
-export const REGISTER_PERSIST_FORM_DATA = 'REGISTER_PERSIST_FORM_DATA';
 export const REGISTER_SET_COUNTRY_CODE = 'REGISTER_SET_COUNTRY_CODE';
 
-// Reset Form
-export const resetRegistrationForm = () => ({
-  type: REGISTRATION_FORM.RESET,
+// Backup registration form
+export const backupRegistrationForm = () => ({
+  type: BACKUP_REGISTRATION_DATA.BASE,
+});
+
+export const backupRegistrationFormBegin = (data) => ({
+  type: BACKUP_REGISTRATION_DATA.BEGIN,
+  payload: { ...data },
+});
+
+// Validate fields from the backend
+export const fetchRealtimeValidations = (formPayload) => ({
+  type: REGISTER_FORM_VALIDATIONS.BASE,
+  payload: { formPayload },
+});
+
+export const fetchRealtimeValidationsBegin = () => ({
+  type: REGISTER_FORM_VALIDATIONS.BEGIN,
+});
+
+export const fetchRealtimeValidationsSuccess = (validations) => ({
+  type: REGISTER_FORM_VALIDATIONS.SUCCESS,
+  payload: { validations },
+});
+
+export const fetchRealtimeValidationsFailure = () => ({
+  type: REGISTER_FORM_VALIDATIONS.FAILURE,
 });
 
 // Register
@@ -33,32 +56,8 @@ export const registerNewUserFailure = (error) => ({
   payload: { ...error },
 });
 
-// Realtime Field validations
-export const fetchRealtimeValidations = (formPayload) => ({
-  type: REGISTER_FORM_VALIDATIONS.BASE,
-  payload: { formPayload },
-});
-
-export const fetchRealtimeValidationsBegin = () => ({
-  type: REGISTER_FORM_VALIDATIONS.BEGIN,
-});
-
-export const fetchRealtimeValidationsSuccess = (validations) => ({
-  type: REGISTER_FORM_VALIDATIONS.SUCCESS,
-  payload: { validations },
-});
-
-export const fetchRealtimeValidationsFailure = () => ({
-  type: REGISTER_FORM_VALIDATIONS.FAILURE,
-});
-
 export const clearUsernameSuggestions = () => ({
   type: REGISTER_CLEAR_USERNAME_SUGGESTIONS,
-});
-
-export const setRegistrationFormData = (formData, clearRegistrationError = false) => ({
-  type: REGISTER_PERSIST_FORM_DATA,
-  payload: { formData, clearRegistrationError },
 });
 
 export const setCountryFromThirdPartyAuthContext = (countryCode) => ({

--- a/src/register/data/reducers.js
+++ b/src/register/data/reducers.js
@@ -3,49 +3,46 @@ import {
   PENDING_STATE,
 } from '../../data/constants';
 import {
+  BACKUP_REGISTRATION_DATA,
   REGISTER_CLEAR_USERNAME_SUGGESTIONS,
   REGISTER_FORM_VALIDATIONS,
   REGISTER_NEW_USER,
-  REGISTER_PERSIST_FORM_DATA, REGISTER_SET_COUNTRY_CODE,
-  REGISTRATION_FORM,
+  REGISTER_SET_COUNTRY_CODE,
 } from './actions';
 
 export const defaultState = {
   registrationError: {},
   registrationResult: {},
   registrationFormData: {
-    country: '',
-    email: '',
-    name: '',
-    password: '',
-    username: '',
-    marketingOptIn: true,
-    errors: {
-      email: '',
-      name: '',
-      username: '',
-      password: '',
-      country: '',
+    formFields: {
+      name: '', email: '', username: '', password: '', marketingEmailsOptIn: true,
     },
-    emailFieldBorderClass: '',
-    emailErrorSuggestion: null,
-    emailWarningSuggestion: null,
+    errors: {
+      name: '', email: '', username: '', password: '',
+    },
+    emailSuggestion: {
+      suggestion: '', type: '',
+    },
   },
   validations: null,
-  statusCode: null,
+  submitState: DEFAULT_STATE,
+  validationApiRateLimited: false,
   usernameSuggestions: [],
-  extendedProfile: [],
-  fieldDescriptions: {},
-  formRenderState: DEFAULT_STATE,
+  shouldBackupState: false,
 };
 
 const reducer = (state = defaultState, action) => {
   switch (action.type) {
-    case REGISTRATION_FORM.RESET:
+    case BACKUP_REGISTRATION_DATA.BASE:
+      return {
+        ...state,
+        shouldBackupState: true,
+      };
+    case BACKUP_REGISTRATION_DATA.BEGIN:
       return {
         ...defaultState,
-        registrationFormData: state.registrationFormData,
         usernameSuggestions: state.usernameSuggestions,
+        registrationFormData: { ...action.payload },
       };
     case REGISTER_NEW_USER.BEGIN:
       return {
@@ -69,10 +66,6 @@ const reducer = (state = defaultState, action) => {
         usernameSuggestions: usernameSuggestions || state.usernameSuggestions,
       };
     }
-    case REGISTER_FORM_VALIDATIONS.BEGIN:
-      return {
-        ...state,
-      };
     case REGISTER_FORM_VALIDATIONS.SUCCESS: {
       const { usernameSuggestions } = action.payload.validations;
       return {
@@ -84,7 +77,7 @@ const reducer = (state = defaultState, action) => {
     case REGISTER_FORM_VALIDATIONS.FAILURE:
       return {
         ...state,
-        statusCode: 403,
+        validationApiRateLimited: true,
         validations: null,
       };
     case REGISTER_CLEAR_USERNAME_SUGGESTIONS:
@@ -92,17 +85,6 @@ const reducer = (state = defaultState, action) => {
         ...state,
         usernameSuggestions: [],
       };
-    case REGISTER_PERSIST_FORM_DATA: {
-      const { formData, clearRegistrationError } = action.payload;
-      return {
-        ...state,
-        registrationError: clearRegistrationError ? {} : state.registrationError,
-        registrationFormData: {
-          ...state.registrationFormData,
-          ...formData,
-        },
-      };
-    }
     case REGISTER_SET_COUNTRY_CODE: {
       const { countryCode } = action.payload;
       if (state.registrationFormData.country === '') {
@@ -117,7 +99,10 @@ const reducer = (state = defaultState, action) => {
       return state;
     }
     default:
-      return state;
+      return {
+        ...state,
+        shouldBackupState: false,
+      };
   }
 };
 

--- a/src/register/data/selectors.js
+++ b/src/register/data/selectors.js
@@ -4,11 +4,6 @@ export const storeName = 'register';
 
 export const registerSelector = state => ({ ...state[storeName] });
 
-export const registrationRequestSelector = createSelector(
-  registerSelector,
-  register => register.registrationResult,
-);
-
 export const registrationErrorSelector = createSelector(
   registerSelector,
   register => register.registrationError.errorCode,
@@ -35,14 +30,4 @@ export const validationsSelector = createSelector(
 
     return null;
   },
-);
-
-export const usernameSuggestionsSelector = createSelector(
-  registerSelector,
-  register => register.usernameSuggestions,
-);
-
-export const registrationFormDataSelector = createSelector(
-  registerSelector,
-  register => register.registrationFormData,
 );

--- a/src/register/data/tests/reducers.test.js
+++ b/src/register/data/tests/reducers.test.js
@@ -1,11 +1,10 @@
 import { DEFAULT_STATE } from '../../../data/constants';
 import {
+  BACKUP_REGISTRATION_DATA,
   REGISTER_CLEAR_USERNAME_SUGGESTIONS,
   REGISTER_FORM_VALIDATIONS,
   REGISTER_NEW_USER,
-  REGISTER_PERSIST_FORM_DATA,
   REGISTER_SET_COUNTRY_CODE,
-  REGISTRATION_FORM,
 } from '../actions';
 import reducer from '../reducers';
 
@@ -16,29 +15,21 @@ describe('register reducer', () => {
         registrationError: {},
         registrationResult: {},
         registrationFormData: {
-          country: '',
-          email: '',
-          name: '',
-          password: '',
-          username: '',
-          marketingOptIn: true,
-          errors: {
-            email: '',
-            name: '',
-            username: '',
-            password: '',
-            country: '',
+          formFields: {
+            name: '', email: '', username: '', password: '', marketingEmailsOptIn: true,
           },
-          emailFieldBorderClass: '',
-          emailErrorSuggestion: null,
-          emailWarningSuggestion: null,
+          errors: {
+            name: '', email: '', username: '', password: '',
+          },
+          emailSuggestion: {
+            suggestion: '', type: '',
+          },
         },
         validations: null,
-        statusCode: null,
+        submitState: DEFAULT_STATE,
+        validationApiRateLimited: false,
         usernameSuggestions: [],
-        extendedProfile: [],
-        fieldDescriptions: {},
-        formRenderState: DEFAULT_STATE,
+        shouldBackupState: false,
       },
     );
   });
@@ -46,25 +37,8 @@ describe('register reducer', () => {
   it('should set username suggestions upon validation failed case', () => {
     const state = {
       usernameSuggestions: [],
-      registrationFormData: {
-        country: '',
-        email: '',
-        name: '',
-        password: '',
-        username: '',
-        marketingOptIn: true,
-        errors: {
-          email: '',
-          name: '',
-          username: '',
-          password: '',
-          country: '',
-        },
-        emailFieldBorderClass: '',
-        emailErrorSuggestion: null,
-        emailWarningSuggestion: null,
-      },
     };
+
     const validations = { usernameSuggestions: ['test12'], validationDecisions: {} };
     const action = {
       type: REGISTER_FORM_VALIDATIONS.SUCCESS,
@@ -76,24 +50,6 @@ describe('register reducer', () => {
     ).toEqual(
       {
         validations,
-        registrationFormData: {
-          country: '',
-          email: '',
-          name: '',
-          password: '',
-          username: '',
-          marketingOptIn: true,
-          errors: {
-            email: '',
-            name: '',
-            username: '',
-            password: '',
-            country: '',
-          },
-          emailFieldBorderClass: '',
-          emailErrorSuggestion: null,
-          emailWarningSuggestion: null,
-        },
         usernameSuggestions: validations.usernameSuggestions,
       },
     );
@@ -142,31 +98,25 @@ describe('register reducer', () => {
       registrationError: {},
       registrationResult: {},
       registrationFormData: {
-        country: 'PK',
-        email: 'test@email.com',
-        name: 'John Doe',
-        password: 'johndoe',
-        username: 'john',
-        marketingOptIn: true,
-        errors: {
-          email: '',
-          name: '',
-          username: '',
-          password: '',
-          country: '',
+        formFields: {
+          name: '', email: '', username: '', password: '', marketingEmailsOptIn: true,
         },
-        emailErrorSuggestion: 'test@email.com',
-        emailWarningSuggestion: 'test@email.com',
+        errors: {
+          name: '', email: '', username: '', password: '',
+        },
+        emailSuggestion: {
+          suggestion: '', type: '',
+        },
       },
       validations: null,
-      statusCode: null,
-      extendedProfile: [],
-      fieldDescriptions: {},
-      formRenderState: DEFAULT_STATE,
+      submitState: DEFAULT_STATE,
+      validationApiRateLimited: false,
       usernameSuggestions: ['test1', 'test2'],
+      shouldBackupState: false,
     };
     const action = {
-      type: REGISTRATION_FORM.RESET,
+      type: BACKUP_REGISTRATION_DATA.BEGIN,
+      payload: { ...state.registrationFormData },
     };
 
     expect(
@@ -176,77 +126,18 @@ describe('register reducer', () => {
     );
   });
 
-  it('should set registrationFormData', () => {
-    const state = {
-      registrationFormData: {
-        country: '',
-        email: '',
-        name: '',
-        password: '',
-        username: '',
-        marketingOptIn: true,
-        errors: {
-          email: '',
-          name: '',
-          username: '',
-          password: '',
-          country: '',
-        },
-        emailErrorSuggestion: null,
-        emailWarningSuggestion: null,
-      },
-    };
-    const formData = {
-      country: 'PK',
-      email: 'test@email.com',
-      name: 'John Doe',
-      password: 'johndoe',
-      username: 'john',
-      emailErrorSuggestion: 'test@email.com',
-      emailWarningSuggestion: 'test@email.com',
-    };
-
-    const action = {
-      type: REGISTER_PERSIST_FORM_DATA,
-      payload: { formData },
-    };
-
-    expect(
-      reducer(state, action),
-    ).toEqual(
-      {
-        registrationFormData: {
-          ...state.registrationFormData,
-          country: 'PK',
-          email: 'test@email.com',
-          name: 'John Doe',
-          password: 'johndoe',
-          username: 'john',
-          emailErrorSuggestion: 'test@email.com',
-          emailWarningSuggestion: 'test@email.com',
-        },
-      },
-    );
-  });
-
   it('should set country code from context', () => {
     const state = {
       registrationFormData: {
-        country: '',
-        email: '',
-        name: '',
-        password: '',
-        username: '',
-        marketingOptIn: true,
-        errors: {
-          email: '',
-          name: '',
-          username: '',
-          password: '',
-          country: '',
+        formFields: {
+          name: '', email: '', username: '', password: '', marketingEmailsOptIn: true,
         },
-        emailErrorSuggestion: null,
-        emailWarningSuggestion: null,
+        errors: {
+          name: '', email: '', username: '', password: '',
+        },
+        emailSuggestion: {
+          suggestion: '', type: '',
+        },
       },
     };
     const countryCode = 'PK';

--- a/src/register/registrationFields/CountryDropdown.jsx
+++ b/src/register/registrationFields/CountryDropdown.jsx
@@ -5,8 +5,8 @@ import { ExpandLess, ExpandMore } from '@edx/paragon/icons';
 import PropTypes from 'prop-types';
 import onClickOutside from 'react-onclickoutside';
 
-import { FormGroup } from '../common-components';
-import { FORM_SUBMISSION_ERROR } from './data/constants';
+import { FormGroup } from '../../common-components';
+import { FORM_SUBMISSION_ERROR } from '../data/constants';
 
 class CountryDropdown extends React.Component {
   constructor(props) {

--- a/src/register/registrationFields/EmailField.jsx
+++ b/src/register/registrationFields/EmailField.jsx
@@ -1,0 +1,82 @@
+import React from 'react';
+
+import { injectIntl, intlShape } from '@edx/frontend-platform/i18n';
+import { Alert, Icon } from '@edx/paragon';
+import { Close, Error } from '@edx/paragon/icons';
+import PropTypes from 'prop-types';
+
+import { FormGroup } from '../../common-components';
+import messages from '../messages';
+
+const EmailField = (props) => {
+  const {
+    intl,
+    emailSuggestion,
+    handleSuggestionClick,
+    handleOnClose,
+  } = props;
+
+  const renderEmailFeedback = () => {
+    if (emailSuggestion.type === 'error') {
+      return (
+        <Alert variant="danger" className="email-error-alert mt-1" icon={Error}>
+          <span className="alert-text">
+            {intl.formatMessage(messages['did.you.mean.alert.text'])}{' '}
+            <Alert.Link
+              href="#"
+              name="email"
+              onClick={handleSuggestionClick}
+            >
+              {emailSuggestion.suggestion}
+            </Alert.Link>?<Icon src={Close} className="alert-close" onClick={handleOnClose} tabIndex="0" />
+          </span>
+        </Alert>
+      );
+    }
+    return (
+      <span className="small">
+        {intl.formatMessage(messages['did.you.mean.alert.text'])}:{' '}
+        <Alert.Link
+          href="#"
+          name="email"
+          className="email-warning-alert-link"
+          onClick={handleSuggestionClick}
+        >
+          {emailSuggestion.suggestion}
+        </Alert.Link>?
+      </span>
+    );
+  };
+
+  return (
+    <FormGroup
+      borderClass={emailSuggestion.type === 'warning' ? 'yellow-border' : ''}
+      maxLength={254} // Limit per RFCs is 254
+      {...props}
+    >
+      {emailSuggestion.suggestion ? renderEmailFeedback() : null}
+    </FormGroup>
+  );
+};
+
+EmailField.defaultProps = {
+  emailSuggestion: {
+    suggestion: '',
+    type: '',
+  },
+  errorMessage: '',
+};
+
+EmailField.propTypes = {
+  errorMessage: PropTypes.string,
+  emailSuggestion: PropTypes.shape({
+    suggestion: PropTypes.string,
+    type: PropTypes.string,
+  }),
+  intl: intlShape.isRequired,
+  value: PropTypes.string.isRequired,
+  handleOnClose: PropTypes.func.isRequired,
+  handleSuggestionClick: PropTypes.func.isRequired,
+};
+
+export default injectIntl(EmailField);

--- a/src/register/registrationFields/HonorCode.jsx
+++ b/src/register/registrationFields/HonorCode.jsx
@@ -5,7 +5,7 @@ import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/
 import { Form, Hyperlink } from '@edx/paragon';
 import PropTypes from 'prop-types';
 
-import messages from './messages';
+import messages from '../messages';
 
 const HonorCode = (props) => {
   const {

--- a/src/register/registrationFields/TermsOfService.jsx
+++ b/src/register/registrationFields/TermsOfService.jsx
@@ -5,7 +5,7 @@ import { FormattedMessage, injectIntl, intlShape } from '@edx/frontend-platform/
 import { Form, Hyperlink } from '@edx/paragon';
 import PropTypes from 'prop-types';
 
-import messages from './messages';
+import messages from '../messages';
 
 const TermsOfService = (props) => {
   const {

--- a/src/register/registrationFields/UsernameField.jsx
+++ b/src/register/registrationFields/UsernameField.jsx
@@ -5,11 +5,13 @@ import { Button, Icon, IconButton } from '@edx/paragon';
 import { Close } from '@edx/paragon/icons';
 import PropTypes, { string } from 'prop-types';
 
-import { FormGroup } from '../common-components';
-import messages from './messages';
+import { FormGroup } from '../../common-components';
+import messages from '../messages';
 
 const UsernameField = (props) => {
-  const { intl, usernameSuggestions, errorMessage } = props;
+  const {
+    intl, handleSuggestionClick, handleUsernameSuggestionClose, usernameSuggestions, errorMessage,
+  } = props;
   let className = '';
   let suggestedUsernameDiv = <></>;
   let iconButton = <></>;
@@ -24,7 +26,7 @@ const UsernameField = (props) => {
             variant="outline-dark"
             className="username-suggestion data-hj-suppress"
             key={`suggestion-${index.toString()}`}
-            onClick={(e) => props.handleSuggestionClick(e, username)}
+            onClick={(e) => handleSuggestionClick(e, 'username', username)}
           >
             {username}
           </Button>
@@ -35,11 +37,11 @@ const UsernameField = (props) => {
   );
   if (usernameSuggestions.length > 0 && errorMessage && props.value === ' ') {
     className = 'suggested-username-with-error';
-    iconButton = <IconButton src={Close} iconAs={Icon} alt="Close" onClick={() => props.handleUsernameSuggestionClose()} variant="black" size="sm" className="suggested-username-close-button" />;
+    iconButton = <IconButton src={Close} iconAs={Icon} alt="Close" onClick={() => handleUsernameSuggestionClose()} variant="black" size="sm" className="suggested-username-close-button" />;
     suggestedUsernameDiv = suggestedUsernames();
   } else if (usernameSuggestions.length > 0 && props.value === ' ') {
     className = 'suggested-username';
-    iconButton = <IconButton src={Close} iconAs={Icon} alt="Close" onClick={() => props.handleUsernameSuggestionClose()} variant="black" size="sm" className="suggested-username-close-button" />;
+    iconButton = <IconButton src={Close} iconAs={Icon} alt="Close" onClick={() => handleUsernameSuggestionClose()} variant="black" size="sm" className="suggested-username-close-button" />;
     suggestedUsernameDiv = suggestedUsernames();
   } else if (usernameSuggestions.length > 0 && errorMessage) {
     suggestedUsernameDiv = suggestedUsernames();
@@ -53,15 +55,13 @@ const UsernameField = (props) => {
 
 UsernameField.defaultProps = {
   usernameSuggestions: [],
-  handleSuggestionClick: () => {},
-  handleUsernameSuggestionClose: () => {},
   errorMessage: '',
 };
 
 UsernameField.propTypes = {
   usernameSuggestions: PropTypes.arrayOf(string),
-  handleSuggestionClick: PropTypes.func,
-  handleUsernameSuggestionClose: PropTypes.func,
+  handleSuggestionClick: PropTypes.func.isRequired,
+  handleUsernameSuggestionClose: PropTypes.func.isRequired,
   errorMessage: PropTypes.string,
   intl: intlShape.isRequired,
   name: PropTypes.string.isRequired,

--- a/src/register/registrationFields/index.js
+++ b/src/register/registrationFields/index.js
@@ -1,0 +1,5 @@
+export { default as EmailField } from './EmailField';
+export { default as UsernameField } from './UsernameField';
+export { default as CountryField } from './CountryDropdown';
+export { default as HonorCode } from './HonorCode';
+export { default as TermsOfService } from './TermsOfService';

--- a/src/register/tests/HonorCode.test.jsx
+++ b/src/register/tests/HonorCode.test.jsx
@@ -4,7 +4,7 @@ import { mergeConfig } from '@edx/frontend-platform';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { mount } from 'enzyme';
 
-import HonorCode from '../HonorCode';
+import HonorCode from '../registrationFields/HonorCode';
 
 const IntlHonorCode = injectIntl(HonorCode);
 

--- a/src/register/tests/TermsOfService.test.jsx
+++ b/src/register/tests/TermsOfService.test.jsx
@@ -4,7 +4,7 @@ import { mergeConfig } from '@edx/frontend-platform';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { mount } from 'enzyme';
 
-import TermsOfService from '../TermsOfService';
+import TermsOfService from '../registrationFields/TermsOfService';
 
 const IntlTermsOfService = injectIntl(TermsOfService);
 

--- a/src/register/utils.js
+++ b/src/register/utils.js
@@ -1,8 +1,10 @@
 import { distance } from 'fastest-levenshtein';
 
-import { COMMON_EMAIL_PROVIDERS } from './data/constants';
+import {
+  COMMON_EMAIL_PROVIDERS, DEFAULT_SERVICE_PROVIDER_DOMAINS, DEFAULT_TOP_LEVEL_DOMAINS,
+} from './data/constants';
 
-export function getLevenshteinSuggestion(word, knownWords, similarityThreshold = 4) {
+function getLevenshteinSuggestion(word, knownWords, similarityThreshold = 4) {
   if (!word) {
     return null;
   }
@@ -23,7 +25,7 @@ export function getLevenshteinSuggestion(word, knownWords, similarityThreshold =
 
 export function getSuggestionForInvalidEmail(domain, username) {
   if (!domain) {
-    return null;
+    return '';
   }
 
   const defaultDomains = ['yahoo', 'aol', 'hotmail', 'live', 'outlook', 'gmail'];
@@ -39,5 +41,43 @@ export function getSuggestionForInvalidEmail(domain, username) {
     }
   }
 
-  return null;
+  return '';
+}
+
+export function validateEmailAddress(value, username, domainName) {
+  let suggestion = null;
+  const validation = {
+    hasError: false,
+    suggestion: '',
+    type: '',
+  };
+
+  const hasMultipleSubdomains = value.match(/\./g).length > 1;
+  const [serviceLevelDomain, topLevelDomain] = domainName.split('.');
+  const tldSuggestion = !DEFAULT_TOP_LEVEL_DOMAINS.includes(topLevelDomain);
+  const serviceSuggestion = getLevenshteinSuggestion(serviceLevelDomain, DEFAULT_SERVICE_PROVIDER_DOMAINS, 2);
+
+  if (DEFAULT_SERVICE_PROVIDER_DOMAINS.includes(serviceSuggestion || serviceLevelDomain)) {
+    suggestion = `${username}@${serviceSuggestion || serviceLevelDomain}.com`;
+  }
+
+  if (!hasMultipleSubdomains && tldSuggestion) {
+    validation.suggestion = suggestion;
+    validation.type = 'error';
+  } else if (serviceSuggestion) {
+    validation.suggestion = suggestion;
+    validation.type = 'warning';
+  } else {
+    suggestion = getLevenshteinSuggestion(domainName, COMMON_EMAIL_PROVIDERS, 3);
+    if (suggestion) {
+      validation.suggestion = `${username}@${suggestion}`;
+      validation.type = 'warning';
+    }
+  }
+
+  if (!hasMultipleSubdomains && tldSuggestion) {
+    validation.hasError = true;
+  }
+
+  return validation;
 }

--- a/src/reset-password/ResetPasswordPage.jsx
+++ b/src/reset-password/ResetPasswordPage.jsx
@@ -94,12 +94,12 @@ const ResetPasswordPage = (props) => {
     // Do not validate when focus out from 'newPassword' and focus on 'passwordValidation' icon
     // for better user experience.
     if (event.relatedTarget
-      && event.relatedTarget.name === 'passwordValidation'
+      && event.relatedTarget.name === 'password'
       && name === 'newPassword'
     ) {
       return;
     }
-    if (name === 'passwordValidation') {
+    if (name === 'password') {
       name = 'newPassword';
       value = newPassword;
     }

--- a/src/sass/_registration.scss
+++ b/src/sass/_registration.scss
@@ -1,0 +1,3 @@
+.register-stateful-button-width {
+  min-width: 14.4rem;
+}

--- a/src/sass/_style.scss
+++ b/src/sass/_style.scss
@@ -1,5 +1,6 @@
 // Load component based styles
 @import "_base_component.scss";
+@import "_registration.scss";
 //
 // ----------------------------
 // #COLORS
@@ -44,10 +45,6 @@ $elevation-level-2-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.15);
 
 .stateful-button-width {
   width: 12rem;
-}
-
-.register-stateful-button-width {
-  min-width: 14.4rem;
 }
 
 .login-button-width {


### PR DESCRIPTION
What this PR covers:

- The default registration fields which include:
   - name
   - email
   - username
   - password
 - On Blur and On Focus events
 - Frontend and backend validations for these fields
 - Empty form submission error
   - Error under the fields
   - Error alert over the form 
 - Any backend error that occurred when creating a new user
 - Persist state for errors and field values on tab switch

What this PR **doesn't** cover:
- Failing tests are not catered in this ticket. There is a separate ticket for it.
- Any lint errors related to imports are not fixed.
- Successful creation of user account. This will be covered once we add dynamic fields (which includes the country and honor code fields).
- Redirection is not covered in this PR

Ticket: https://2u-internal.atlassian.net/browse/VAN-1069