### PR TITLE
RTL: Fix skewed and slanted graphics

### DIFF
--- a/src/sass/_base_component.scss
+++ b/src/sass/_base_component.scss
@@ -168,6 +168,15 @@ $accent-a-light: #c9f2f5;
   fill: $primary-400;
 }
 
+[dir=rtl]{
+  .medium-screen-svg-light,
+  .medium-screen-svg-primary,
+  .large-screen-svg-light,
+  .large-screen-svg-primary {
+    transform: scaleX(-1);
+  }
+}
+
 .small-yellow-line {
   width: 80px;
   height: 0;


### PR DESCRIPTION
# Contribution
* Adds RTL support to skewed rectangle transformation 
* With this fix, the skew transformation becomes tilted to the right in LTR and to the left in RTL.
* All screen sizes are covered by this fix

# Background
When using the authentication MFE in an RTL language (Arabic for instance), the tilted line  separating  the "Start Learning with <platform name>" block from the page forms is not rendered correctly

# Screenshots
Faulty layout in RTL
![image](https://user-images.githubusercontent.com/10594967/188925998-9bfde739-17c6-47d1-a851-bdc57c1f499c.png)

Fixed layout in RTL
![image](https://user-images.githubusercontent.com/10594967/188925333-8d7f8cf6-655a-40fb-8002-f049f1b4f88e.png)
