### PR TITLE
fix: update set state functions to use prevState

### DIFF
--- a/src/register/ConfigurableRegistrationForm.jsx
+++ b/src/register/ConfigurableRegistrationForm.jsx
@@ -49,7 +49,7 @@ const ConfigurableRegistrationForm = (props) => {
 
   useEffect(() => {
     if (!formFields.country) {
-      setFormFields({ ...formFields, country: { countryCode: '', displayValue: '' } });
+      setFormFields(prevState => ({ ...prevState, country: { countryCode: '', displayValue: '' } }));
     }
   });
 
@@ -61,10 +61,10 @@ const ConfigurableRegistrationForm = (props) => {
     } else {
       value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
       if (type === 'checkbox') {
-        setFieldErrors({ ...fieldErrors, [name]: '' });
+        setFieldErrors(prevErrors => ({ ...prevErrors, [name]: '' }));
       }
     }
-    setFormFields({ ...formFields, [name]: value });
+    setFormFields(prevState => ({ ...prevState, [name]: value }));
   };
 
   const handleOnBlur = (event) => {
@@ -76,19 +76,19 @@ const ConfigurableRegistrationForm = (props) => {
       );
       const { countryCode, displayValue } = countryValidation;
       error = countryValidation.error;
-      setFormFields({ ...formFields, country: { countryCode, displayValue } });
+      setFormFields(prevState => ({ ...prevState, country: { countryCode, displayValue } }));
     } else if (!value || !value.trim()) {
       error = fieldDescriptions[name].error_message;
     } else if (name === 'confirm_email' && value !== email) {
       error = intl.formatMessage(messages['email.do.not.match']);
     }
     setFocusedField(null);
-    setFieldErrors({ ...fieldErrors, [name]: error });
+    setFieldErrors(prevErrors => ({ ...prevErrors, [name]: error }));
   };
 
   const handleOnFocus = (event) => {
     const { name } = event.target;
-    setFieldErrors({ ...fieldErrors, [name]: '' });
+    setFieldErrors(prevErrors => ({ ...prevErrors, [name]: '' }));
     // Since we are removing the form errors from the focused field, we will
     // need to rerun the validation for focused field on form submission.
     setFocusedField(name);

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -172,7 +172,7 @@ const RegistrationPage = (props) => {
    */
   useEffect(() => {
     if (usernameSuggestions.length && !formFields.username) {
-      setFormFields({ ...formFields, username: ' ' });
+      setFormFields(prevState => ({ ...prevState, username: ' ' }));
     }
   }, [usernameSuggestions, formFields]);
 
@@ -261,7 +261,7 @@ const RegistrationPage = (props) => {
           );
           fieldError = error;
           countryFieldCode = countryCode;
-          setConfigurableFormFields({ ...configurableFormFields, country: { countryCode, displayValue } });
+          setConfigurableFormFields(prevState => ({ ...prevState, country: { countryCode, displayValue } }));
         }
         break;
       default:
@@ -275,11 +275,11 @@ const RegistrationPage = (props) => {
         break;
     }
     if (setError) {
-      setErrors({
-        ...errors,
+      setErrors(prevErrors => ({
+        ...prevErrors,
         confirm_email: flags.showConfigurableRegistrationFields ? confirmEmailError : '',
         [fieldName]: fieldError,
-      });
+      }));
     }
     return { fieldError, countryFieldCode };
   };
@@ -327,14 +327,14 @@ const RegistrationPage = (props) => {
 
   const handleSuggestionClick = (event, fieldName, suggestion = '') => {
     event.preventDefault();
-    setErrors({ ...errors, [fieldName]: '' });
+    setErrors(prevErrors => ({ ...prevErrors, [fieldName]: '' }));
     switch (fieldName) {
       case 'email':
-        setFormFields({ ...formFields, email: emailSuggestion.suggestion });
+        setFormFields(prevState => ({ ...prevState, email: emailSuggestion.suggestion }));
         setEmailSuggestion({ suggestion: '', type: '' });
         break;
       case 'username':
-        setFormFields({ ...formFields, username: suggestion });
+        setFormFields(prevState => ({ ...prevState, username: suggestion }));
         props.resetUsernameSuggestions();
         break;
       default:
@@ -346,9 +346,10 @@ const RegistrationPage = (props) => {
   const handleUsernameSuggestionClosed = () => props.resetUsernameSuggestions();
 
   const handleOnChange = (event) => {
+    const { name } = event.target;
     let value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
 
-    if (event.target.name === 'username') {
+    if (name === 'username') {
       if (value.length > 30) {
         return;
       }
@@ -357,7 +358,7 @@ const RegistrationPage = (props) => {
       }
     }
 
-    setFormFields({ ...formFields, [event.target.name]: value });
+    setFormFields(prevState => ({ ...prevState, [name]: value }));
   };
 
   const handleOnBlur = (event) => {
@@ -376,7 +377,7 @@ const RegistrationPage = (props) => {
 
   const handleOnFocus = (event) => {
     const { name, value } = event.target;
-    setErrors({ ...errors, [name]: '' });
+    setErrors(prevErrors => ({ ...prevErrors, [name]: '' }));
     // Since we are removing the form errors from the focused field, we will
     // need to rerun the validation for focused field on form submission.
     setFocusedField(name);
@@ -387,7 +388,7 @@ const RegistrationPage = (props) => {
       // remove it before user enters the input. This is to ensure user doesn't
       // have a space prefixed to the username.
       if (value === ' ') {
-        setFormFields({ ...formFields, [name]: '' });
+        setFormFields(prevState => ({ ...prevState, [name]: '' }));
       }
     }
   };

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -946,7 +946,7 @@ describe('RegistrationPage', () => {
       expect(registrationPage.find('.email-warning-alert-link').first().text()).toEqual('john.doe@hotmail.com');
     });
 
-    it('should set country in component state on country change with translations', () => {
+    it('should set country in component state when form is translated used i18n', () => {
       getLocale.mockImplementation(() => ('ar-ae'));
 
       const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
@@ -955,7 +955,7 @@ describe('RegistrationPage', () => {
       expect(registrationPage.find('div[feedback-for="country"]').exists()).toBeFalsy();
     });
 
-    it('should set country in component state on country change with chrome translations', () => {
+    it('should set country in component state when form is translated using browser translations', () => {
       getLocale.mockImplementation(() => ('en-us'));
 
       store.dispatch = jest.fn(store.dispatch);
@@ -1092,6 +1092,16 @@ describe('RegistrationPage', () => {
       registrationPage.find('button.btn-brand').simulate('click');
 
       expect(registrationPage.find('#profession-error').last().text()).toEqual(professionError);
+    });
+
+    it('should not remove errors from form fields when country is selected by clicking on expand button', () => {
+      const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
+      registrationPage.find('button.btn-brand').simulate('click');
+      expect(registrationPage.find('div[feedback-for="name"]').exists()).toBeTruthy();
+
+      registrationPage.find('button.expand-more').simulate('click');
+      registrationPage.find('button.dropdown-item').at(0).simulate('click', { target: { value: 'Pakistan', name: 'countryItem' } });
+      expect(registrationPage.find('div[feedback-for="name"]').exists()).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
### Description

Relying on the outer state causes unexpected issues. During set state, use the react's internal state to refer to previous values. 

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.