### PR TITLE
fix: add proper error handling for progressive profiling page.

### DIFF
--- a/src/welcome/ProgressiveProfiling.jsx
+++ b/src/welcome/ProgressiveProfiling.jsx
@@ -37,8 +37,6 @@ const ProgressiveProfiling = (props) => {
   const {
     formRenderState, intl, submitState, showError,
   } = props;
-  const optionalFields = props.location.state.optionalFields.fields;
-  const extendedProfile = props.location.state.optionalFields.extended_profile;
   const [ready, setReady] = useState(false);
   const [registrationResult, setRegistrationResult] = useState({ redirectUrl: '' });
   const [values, setValues] = useState({});
@@ -69,6 +67,8 @@ const ProgressiveProfiling = (props) => {
     return null;
   }
 
+  const optionalFields = props.location.state.optionalFields.fields;
+  const extendedProfile = props.location.state.optionalFields.extended_profile;
   const handleSubmit = (e) => {
     e.preventDefault();
     const authenticatedUser = getAuthenticatedUser();
@@ -193,8 +193,6 @@ const ProgressiveProfiling = (props) => {
 
 ProgressiveProfiling.propTypes = {
   // eslint-disable-next-line react/no-unused-prop-types
-  extendedProfile: PropTypes.arrayOf(PropTypes.string),
-  optionalFields: PropTypes.shape({}),
   formRenderState: PropTypes.string.isRequired,
   intl: intlShape.isRequired,
   location: PropTypes.shape({
@@ -207,8 +205,6 @@ ProgressiveProfiling.propTypes = {
 };
 
 ProgressiveProfiling.defaultProps = {
-  extendedProfile: [],
-  optionalFields: {},
   location: { state: {} },
   shouldRedirect: false,
   showError: false,


### PR DESCRIPTION
### Description

Fix that progressive profiling page to stop showing the optional field error and also Verify twelcome page is not accessible when directly hit from the browser.

### https://2u-internal.atlassian.net/browse/VAN-1215

#### How Has This Been Tested?

Please describe in detail how you tested your changes.

#### Screenshots/sandbox (optional):
Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if its not applicable.**

|Before|After|
|-------|-----|
|      |      |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.