### PR TITLE
fix: Use repo name, spaces are not allowed.

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,7 +4,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: 'Authentication Frontend'
+  name: 'frontend-app-authn'
   description: "Micro-frontend for authentication service. It contains views for login, registration and password reset functionality."
   links:
     - url: 'https://github.com/openedx/frontend-app-authn/blob/master/README.rst'


### PR DESCRIPTION
### Description

This PR fixes an issue with the syntax of the catalog-info.yaml file.  Once merged this application will be imported into Backstage.

The relevant log message is:

```json
{
   "entity":"component:default/authentication frontend",
   "level":"warn",
   "location":"url:https://github.com/openedx/frontend-app-authn/tree/master/catalog-info.yaml",
   "message":"Policy check failed for component:default/authentication frontend; caused by Error: \"metadata.name\" is not valid; expected a string that is sequences of [a-zA-Z0-9] separated by any of [-_.], at most 63 characters in total but found \"Authentication Frontend\". To learn more about catalog file format, visit: https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr002-default-catalog-file-format.md",
   "plugin":"catalog",
   "service":"backstage",
   "type":"plugin"
}
```
