### PR TITLE
fix: uncaught exception on progressive profiling

### DIFF
--- a/src/common-components/RedirectLogistration.jsx
+++ b/src/common-components/RedirectLogistration.jsx
@@ -9,7 +9,7 @@ import { setCookie } from '../data/utils';
 
 function RedirectLogistration(props) {
   const {
-    finishAuthUrl, redirectUrl, redirectToWelcomePage, success, optionalFields,
+    finishAuthUrl, redirectUrl, redirectToProgressiveProfilingPage, success, optionalFields,
   } = props;
   let finalRedirectUrl = '';
 
@@ -25,7 +25,7 @@ function RedirectLogistration(props) {
     }
 
     // Redirect to Progressive Profiling after successful registration
-    if (redirectToWelcomePage) {
+    if (redirectToProgressiveProfilingPage) {
       // TODO: Do we still need this cookie?
       setCookie('van-504-returning-user', true);
       const registrationResult = { redirectUrl: finalRedirectUrl, success };
@@ -50,7 +50,7 @@ RedirectLogistration.defaultProps = {
   finishAuthUrl: null,
   success: false,
   redirectUrl: '',
-  redirectToWelcomePage: false,
+  redirectToProgressiveProfilingPage: false,
   optionalFields: {},
 };
 
@@ -58,7 +58,7 @@ RedirectLogistration.propTypes = {
   finishAuthUrl: PropTypes.string,
   success: PropTypes.bool,
   redirectUrl: PropTypes.string,
-  redirectToWelcomePage: PropTypes.bool,
+  redirectToProgressiveProfilingPage: PropTypes.bool,
   optionalFields: PropTypes.shape({}),
 };
 

--- a/src/common-components/data/reducers.js
+++ b/src/common-components/data/reducers.js
@@ -23,15 +23,21 @@ const reducer = (state = defaultState, action) => {
         ...state,
         thirdPartyAuthApiStatus: PENDING_STATE,
       };
-    case THIRD_PARTY_AUTH_CONTEXT.SUCCESS:
+    case THIRD_PARTY_AUTH_CONTEXT.SUCCESS: {
+      const extendedProfile = action.payload.optionalFields.extended_profile;
+      const extendedProfileArray = Object.keys(extendedProfile).length !== 0 ? extendedProfile : [];
       return {
         ...state,
-        extendedProfile: action.payload.fieldDescriptions.extended_profile,
+        extendedProfile: extendedProfileArray,
         fieldDescriptions: action.payload.fieldDescriptions.fields,
-        optionalFields: action.payload.optionalFields,
+        optionalFields: {
+          ...action.payload.optionalFields,
+          extended_profile: extendedProfileArray,
+        },
         thirdPartyAuthContext: action.payload.thirdPartyAuthContext,
         thirdPartyAuthApiStatus: COMPLETE_STATE,
       };
+    }
     case THIRD_PARTY_AUTH_CONTEXT.FAILURE:
       return {
         ...state,

--- a/src/common-components/data/tests/reducer.test.js
+++ b/src/common-components/data/tests/reducer.test.js
@@ -1,0 +1,49 @@
+import { THIRD_PARTY_AUTH_CONTEXT } from '../actions';
+import reducer from '../reducers';
+
+describe('common components reducer', () => {
+  it('should convert empty extended profile object to array', () => {
+    const state = {
+      extendedProfile: [],
+      fieldDescriptions: {},
+      optionalFields: {},
+      thirdPartyAuthApiStatus: null,
+      thirdPartyAuthContext: {
+        currentProvider: null,
+        finishAuthUrl: null,
+        countryCode: null,
+        providers: [],
+        secondaryProviders: [],
+        pipelineUserDetails: null,
+      },
+    };
+    const fieldDescriptions = {
+      fields: [],
+      extended_profile: {},
+    };
+    const optionalFields = {
+      fields: [],
+      extended_profile: {},
+    };
+    const thirdPartyAuthContext = { ...state.thirdPartyAuthContext };
+    const action = {
+      type: THIRD_PARTY_AUTH_CONTEXT.SUCCESS,
+      payload: { fieldDescriptions, optionalFields, thirdPartyAuthContext },
+    };
+
+    expect(
+      reducer(state, action),
+    ).toEqual(
+      {
+        ...state,
+        extendedProfile: [],
+        fieldDescriptions: [],
+        optionalFields: {
+          fields: [],
+          extended_profile: [],
+        },
+        thirdPartyAuthApiStatus: 'complete',
+      },
+    );
+  });
+});

--- a/src/progressive-profiling/ProgressiveProfiling.jsx
+++ b/src/progressive-profiling/ProgressiveProfiling.jsx
@@ -46,11 +46,13 @@ const ProgressiveProfiling = (props) => {
 
   useEffect(() => {
     configureAuth(AxiosJwtAuthService, { loggingService: getLoggingService(), config: getConfig() });
-    ensureAuthenticatedUser(DASHBOARD_URL).then(() => {
-      hydrateAuthenticatedUser().then(() => {
-        setReady(true);
-      });
-    });
+    ensureAuthenticatedUser(DASHBOARD_URL)
+      .then(() => {
+        hydrateAuthenticatedUser().then(() => {
+          setReady(true);
+        });
+      })
+      .catch(() => {});
 
     if (props.location.state && props.location.state.registrationResult) {
       setRegistrationResult(props.location.state.registrationResult);
@@ -194,7 +196,6 @@ const ProgressiveProfiling = (props) => {
 };
 
 ProgressiveProfiling.propTypes = {
-  // eslint-disable-next-line react/no-unused-prop-types
   formRenderState: PropTypes.string.isRequired,
   intl: PropTypes.objectOf(PropTypes.object).isRequired,
   location: PropTypes.shape({

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -461,7 +461,7 @@ const RegistrationPage = (props) => {
           redirectUrl={registrationResult.redirectUrl}
           finishAuthUrl={finishAuthUrl}
           optionalFields={optionalFields}
-          redirectToWelcomePage={
+          redirectToProgressiveProfilingPage={
             getConfig().ENABLE_PROGRESSIVE_PROFILING_ON_AUTHN && Object.keys(optionalFields).length !== 0
           }
         />


### PR DESCRIPTION
Description
frontend-platform's ensureAuthenticatedUser was throwing exceptions in case of the unauthenticated user along with redirecting to the login page. This PR passes that exception.

Why it was reverted earlier? 
I had extended_profile configuration set to string instead it should be set to an array. So in code, I was converting string to an array which was not needed actually and was causing exception. which is resolved now.

[VAN-1224](https://2u-internal.atlassian.net/browse/VAN-1224)