### PR TITLE
fix: update MFE context

### DIFF
--- a/src/common-components/data/reducers.js
+++ b/src/common-components/data/reducers.js
@@ -2,7 +2,6 @@ import { COMPLETE_STATE, PENDING_STATE } from '../../data/constants';
 import { THIRD_PARTY_AUTH_CONTEXT } from './actions';
 
 export const defaultState = {
-  extendedProfile: [],
   fieldDescriptions: {},
   optionalFields: {},
   thirdPartyAuthApiStatus: null,
@@ -24,20 +23,10 @@ const reducer = (state = defaultState, action) => {
         thirdPartyAuthApiStatus: PENDING_STATE,
       };
     case THIRD_PARTY_AUTH_CONTEXT.SUCCESS: {
-      const extendedProfile = action.payload.optionalFields.extended_profile;
-      let extendedProfileArray = [];
-      if (extendedProfile && Object.keys(extendedProfile).length !== 0) {
-        extendedProfileArray = extendedProfile;
-      }
-
       return {
         ...state,
-        extendedProfile: extendedProfileArray,
         fieldDescriptions: action.payload.fieldDescriptions.fields,
-        optionalFields: {
-          ...action.payload.optionalFields,
-          extended_profile: extendedProfileArray,
-        },
+        optionalFields: action.payload.optionalFields,
         thirdPartyAuthContext: action.payload.thirdPartyAuthContext,
         thirdPartyAuthApiStatus: COMPLETE_STATE,
       };

--- a/src/common-components/data/selectors.js
+++ b/src/common-components/data/selectors.js
@@ -14,11 +14,6 @@ export const fieldDescriptionSelector = createSelector(
   commonComponents => commonComponents.fieldDescriptions,
 );
 
-export const extendedProfileSelector = createSelector(
-  commonComponentsSelector,
-  commonComponents => commonComponents.extendedProfile,
-);
-
 export const optionalFieldsSelector = createSelector(
   commonComponentsSelector,
   commonComponents => commonComponents.optionalFields,

--- a/src/common-components/data/tests/reducer.test.js
+++ b/src/common-components/data/tests/reducer.test.js
@@ -2,9 +2,8 @@ import { THIRD_PARTY_AUTH_CONTEXT } from '../actions';
 import reducer from '../reducers';
 
 describe('common components reducer', () => {
-  it('should convert empty extended profile object to array', () => {
+  it('test mfe context response', () => {
     const state = {
-      extendedProfile: [],
       fieldDescriptions: {},
       optionalFields: {},
       thirdPartyAuthApiStatus: null,
@@ -19,7 +18,6 @@ describe('common components reducer', () => {
     };
     const fieldDescriptions = {
       fields: [],
-      extended_profile: {},
     };
     const optionalFields = {
       fields: [],
@@ -36,11 +34,10 @@ describe('common components reducer', () => {
     ).toEqual(
       {
         ...state,
-        extendedProfile: [],
         fieldDescriptions: [],
         optionalFields: {
           fields: [],
-          extended_profile: [],
+          extended_profile: {},
         },
         thirdPartyAuthApiStatus: 'complete',
       },

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -19,7 +19,7 @@ import {
 } from '../common-components';
 import { getThirdPartyAuthContext } from '../common-components/data/actions';
 import {
-  extendedProfileSelector, fieldDescriptionSelector, optionalFieldsSelector, thirdPartyAuthContextSelector,
+  fieldDescriptionSelector, optionalFieldsSelector, thirdPartyAuthContextSelector,
 } from '../common-components/data/selectors';
 import EnterpriseSSO from '../common-components/EnterpriseSSO';
 import {
@@ -595,7 +595,6 @@ const mapStateToProps = state => {
     backendCountryCode: registerPageState.backendCountryCode,
     backendValidations: validationsSelector(state),
     fieldDescriptions: fieldDescriptionSelector(state),
-    extendedProfile: extendedProfileSelector(state),
     optionalFields: optionalFieldsSelector(state),
     registrationErrorCode: registrationErrorSelector(state),
     registrationResult: registerPageState.registrationResult,
@@ -623,7 +622,6 @@ RegistrationPage.propTypes = {
     username: PropTypes.string,
     password: PropTypes.string,
   }),
-  extendedProfile: PropTypes.arrayOf(PropTypes.string),
   fieldDescriptions: PropTypes.shape({}),
   institutionLogin: PropTypes.bool.isRequired,
   intl: PropTypes.objectOf(PropTypes.object).isRequired,
@@ -681,7 +679,6 @@ RegistrationPage.defaultProps = {
   },
   backendCountryCode: '',
   backendValidations: null,
-  extendedProfile: [],
   fieldDescriptions: {},
   optionalFields: {},
   registrationErrorCode: '',

--- a/src/register/registrationFields/HonorCode.jsx
+++ b/src/register/registrationFields/HonorCode.jsx
@@ -56,7 +56,7 @@ const HonorCode = (props) => {
       >
         <FormattedMessage
           id="register.page.honor.code"
-          defaultMessage="I agree to the {platformName} {tosAndHonorCode}"
+          defaultMessage="I agree to the {platformName}&nbsp;{tosAndHonorCode}"
           description="Text that appears on registration form stating honor code"
           values={{
             platformName: getConfig().SITE_NAME,

--- a/src/register/registrationFields/TermsOfService.jsx
+++ b/src/register/registrationFields/TermsOfService.jsx
@@ -24,7 +24,7 @@ const TermsOfService = (props) => {
       >
         <FormattedMessage
           id="register.page.terms.of.service"
-          defaultMessage="I agree to the {platformName} {termsOfService}"
+          defaultMessage="I agree to the {platformName}&nbsp;{termsOfService}"
           description="Text that appears on registration form stating terms of service.
                        It is a legal document that users must agree to."
           values={{

--- a/src/register/tests/HonorCode.test.jsx
+++ b/src/register/tests/HonorCode.test.jsx
@@ -37,7 +37,7 @@ describe('HonorCodeTest', () => {
   });
 
   it('should render Honor code field', () => {
-    const expectedMsg = 'I agree to the Your Platform Name Here Honor Codein a new tab';
+    const expectedMsg = 'I agree to the Your Platform Name Here\u00a0Honor Codein a new tab';
     const honorCode = mount(
       <IntlProvider locale="en">
         <IntlHonorCode onChangeHandler={changeHandler} />

--- a/src/register/tests/TermsOfService.test.jsx
+++ b/src/register/tests/TermsOfService.test.jsx
@@ -35,7 +35,7 @@ describe('TermsOfServiceTest', () => {
         <IntlTermsOfService onChangeHandler={changeHandler} />
       </IntlProvider>,
     );
-    const expectedMsg = 'I agree to the Your Platform Name Here Terms of Servicein a new tab';
+    const expectedMsg = 'I agree to the Your Platform Name Here\u00a0Terms of Servicein a new tab';
     expect(termsOfService.find('#terms-of-service').find('label').text()).toEqual(expectedMsg);
     expect(value).toEqual(false);
   });


### PR DESCRIPTION
[VAN-1231](https://2u-internal.atlassian.net/browse/VAN-1230)

### Description

removed unused extendedProfile object from the registration page and added space before the honor code and TOS link.

#### How Has This Been Tested?

Tested locally by registering with additional registration and optional fields and checking if they are saved correctly at the backend.

