### PR TITLE
fix: sso button not appearing on login page

### DIFF
--- a/src/common-components/data/reducers.js
+++ b/src/common-components/data/reducers.js
@@ -25,7 +25,11 @@ const reducer = (state = defaultState, action) => {
       };
     case THIRD_PARTY_AUTH_CONTEXT.SUCCESS: {
       const extendedProfile = action.payload.optionalFields.extended_profile;
-      const extendedProfileArray = Object.keys(extendedProfile).length !== 0 ? extendedProfile : [];
+      let extendedProfileArray = [];
+      if (extendedProfile && Object.keys(extendedProfile).length !== 0) {
+        extendedProfileArray = extendedProfile;
+      }
+
       return {
         ...state,
         extendedProfile: extendedProfileArray,


### PR DESCRIPTION
### Description

On login page we do not get additional fields in the MFE context. When the login page tries to get the third party auth context it gives error because `extendedProfile` is undefined.

```javascript
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at reducer (reducers.js?73fe:28:43)
    at combination (redux.js?00d8:560:1)
    at M (<anonymous>:1:32997)
    at z (<anonymous>:1:33284)
    at <anonymous>:1:36378
    at Object.dispatch (redux.js?00d8:288:1)
    at e (<anonymous>:1:37227)
    at eval (redux-logger.js?d665:1:7805)
    at eval (redux-saga-core.esm.js?42a9:1410:1)
```

#### How Has This Been Tested?

Tested the changed locally

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.