### PR TITLE
fix: Progressive Profiling can't convert undefined to object

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -471,7 +471,7 @@ const RegistrationPage = (props) => {
           finishAuthUrl={finishAuthUrl}
           optionalFields={optionalFields}
           redirectToProgressiveProfilingPage={
-            getConfig().ENABLE_PROGRESSIVE_PROFILING_ON_AUTHN && Object.keys(optionalFields).length !== 0
+            getConfig().ENABLE_PROGRESSIVE_PROFILING_ON_AUTHN && Object.keys(optionalFields).includes('fields')
           }
         />
         <div className="mw-xs mt-3">

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -739,6 +739,7 @@ describe('RegistrationPage', () => {
     });
 
     it('should redirect to progressive profiling page if optional fields are configured', () => {
+      getLocale.mockImplementation(() => ('en-us'));
       mergeConfig({
         ENABLE_PROGRESSIVE_PROFILING_ON_AUTHN: true,
       });
@@ -753,7 +754,10 @@ describe('RegistrationPage', () => {
         },
         commonComponents: {
           optionalFields: {
-            country: { name: 'country', error_message: false },
+            extended_profile: {},
+            fields: {
+              level_of_education: { name: 'level_of_education', error_message: false },
+            },
           },
         },
       });


### PR DESCRIPTION
There is a case when an undefined converting to object, fixed that issue.

Ticket: [VAN-1249](https://2u-internal.atlassian.net/browse/VAN-1249) 