### PR TITLE
fix: Customiz Zendesk

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,8 @@
               },
               chat: {
                 suppress: false,
+                departments: {
+                enabled: ['account settings', 'billing and payments', 'certificates', 'deadlines', 'errors and technical issues', 'other', 'proctoring']
               },
               contactForm: {
                 ticketForms: [


### PR DESCRIPTION
Customize the Zendesk Web Widget in authn for edX support for bootcamp.
Learners on the rest of the courses have no access to BootCamp Support unless they are in the Bootcamp Course.

<table>
<tr>
<td>
<h4>Before</h4>
<img width="357" alt="Screenshot 2023-02-06 at 4 31 05 PM" src="https://user-images.githubusercontent.com/78487564/216961528-4ab2e53c-2a5f-4036-9caf-1447f98c70e3.png">
</td>
<td>
<h4>After</h4>
<img width="326" alt="Screenshot 2023-02-06 at 4 32 51 PM" src="https://user-images.githubusercontent.com/78487564/216961930-7c5c93b2-5fd5-4bfc-9127-6423ca4c1097.png">
</td>
</tr>
</table>

**How to test locally:**

1. Set up `ZENDESK_KEY` and `ZENDESK_LOGO_URL` in `env.development`
2. Up the server
3. You will find it on authn

Ticket [link](https://2u-internal.atlassian.net/browse/VAN-1290)

