### PR TITLE
fix: syntext error fixed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,8 @@
               chat: {
                 suppress: false,
                 departments: {
-                enabled: ['account settings', 'billing and payments', 'certificates', 'deadlines', 'errors and technical issues', 'other', 'proctoring']
+                  enabled: ['account settings', 'billing and payments', 'certificates', 'deadlines', 'errors and technical issues', 'other', 'proctoring']
+                }
               },
               contactForm: {
                 ticketForms: [


### PR DESCRIPTION
A closing bracket was missing in zen-desk settings.
