### PR TITLE
feature: don't show support button if it is not used

### DIFF
--- a/src/forgot-password/ForgotPasswordPage.jsx
+++ b/src/forgot-password/ForgotPasswordPage.jsx
@@ -141,16 +141,18 @@ const ForgotPasswordPage = (props) => {
               onClick={handleSubmit}
               onMouseDown={(e) => e.preventDefault()}
             />
-            <Hyperlink
-              id="forgot-password"
-              name="forgot-password"
-              className="ml-4 font-weight-500 text-body"
-              destination={getConfig().LOGIN_ISSUE_SUPPORT_LINK}
-              target="_blank"
-              showLaunchIcon={false}
-            >
-              {intl.formatMessage(messages['need.help.sign.in.text'])}
-            </Hyperlink>
+            {(getConfig().LOGIN_ISSUE_SUPPORT_LINK) && (
+              <Hyperlink
+                id="forgot-password"
+                name="forgot-password"
+                className="ml-4 font-weight-500 text-body"
+                destination={getConfig().LOGIN_ISSUE_SUPPORT_LINK}
+                target="_blank"
+                showLaunchIcon={false}
+              >
+                {intl.formatMessage(messages['need.help.sign.in.text'])}
+              </Hyperlink>
+            )}
             <p className="mt-5.5 small text-gray-700">
               {intl.formatMessage(messages['additional.help.text'], { platformName })}
               <span>

--- a/src/forgot-password/tests/ForgotPasswordPage.test.jsx
+++ b/src/forgot-password/tests/ForgotPasswordPage.test.jsx
@@ -66,7 +66,15 @@ describe('ForgotPasswordPage', () => {
     };
   });
 
+  it('not should display need other help signing in button', () => {
+    const wrapper = mount(reduxWrapper(<IntlForgotPasswordPage {...props} />));
+    expect(wrapper.find('#forgot-password').exists()).toBeFalsy();
+  });
+
   it('should display need other help signing in button', () => {
+    mergeConfig({
+      LOGIN_ISSUE_SUPPORT_LINK: '/support',
+    });
     const wrapper = mount(reduxWrapper(<IntlForgotPasswordPage {...props} />));
     expect(wrapper.find('#forgot-password').first().text()).toEqual('Need help signing in?');
   });


### PR DESCRIPTION
### Description
In the EdX community, support pages are not created in all instances. In this case, links to the support page are always displayed in certain places. The forgot password page has a button **"Need help signing in?"**. Currently, it is impossible to disable this button without removing it. I suggest adding the ability to automatically show or hide this button depending on whether there is a link to the support page in the configuration file (the link is added in LOGIN_ISSUE_SUPPORT_LINK).

#### Screenshots:
**if a link to a support page exists**
![Screen_16](https://user-images.githubusercontent.com/98233552/218186871-c789c9bd-4381-4fb5-a2dd-d9bfb66b914e.png)
**if the link to the support page does not exist**
![Screen_17](https://user-images.githubusercontent.com/98233552/218186886-72a1edd3-5130-4396-97ca-a44d99aee449.png)

#### Merge Checklist

* [x] Is there adequate test coverage for your changes?