### PR TITLE
feat: Fixed missing "Or sign in with" display in some cases

### DIFF
--- a/src/login/LoginPage.jsx
+++ b/src/login/LoginPage.jsx
@@ -170,12 +170,12 @@ class LoginPage extends React.Component {
 
     return (
       <>
-        {((!isEnterpriseLoginDisabled && isSocialAuthActive) || (isEnterpriseLoginDisabled && isInstitutionAuthActive))
-           && (
-             <div className="mt-4 mb-3 h4">
-               {intl.formatMessage(messages['login.other.options.heading'])}
-             </div>
-           )}
+        {(isSocialAuthActive || (isEnterpriseLoginDisabled && isInstitutionAuthActive))
+          && (
+            <div className="mt-4 mb-3 h4">
+              {intl.formatMessage(messages['login.other.options.heading'])}
+            </div>
+          )}
 
         {(!isEnterpriseLoginDisabled && isSocialAuthActive) && (
           <Hyperlink className="btn btn-link btn-sm text-body p-0 mb-4" destination={this.getEnterPriseLoginURL()}>

--- a/src/login/tests/LoginPage.test.jsx
+++ b/src/login/tests/LoginPage.test.jsx
@@ -236,6 +236,162 @@ describe('LoginPage', () => {
     expect(loginPage.text().includes('Or sign in with:')).toBe(false);
   });
 
+  it('should show sign-in header providers (ENABLE ENTERPRISE LOGIN)', () => {
+    mergeConfig({
+      DISABLE_ENTERPRISE_LOGIN: '',
+    });
+
+    store = mockStore({
+      ...initialState,
+      commonComponents: {
+        ...initialState.commonComponents,
+        thirdPartyAuthContext: {
+          ...initialState.commonComponents.thirdPartyAuthContext,
+          providers: [{
+            ...ssoProvider,
+          }],
+        },
+      },
+    });
+
+    const loginPage = mount(reduxWrapper(<IntlLoginPage {...props} />));
+    expect(loginPage.text().includes('Or sign in with:')).toBe(true);
+    expect(loginPage.text().includes('Company or school credentials')).toBe(true);
+    expect(loginPage.text().includes('Institution/campus credentials')).toBe(false);
+  });
+
+  it('should show sign-in header with providers (DISABLE ENTERPRISE LOGIN)', () => {
+    mergeConfig({
+      DISABLE_ENTERPRISE_LOGIN: true,
+    });
+
+    store = mockStore({
+      ...initialState,
+      commonComponents: {
+        ...initialState.commonComponents,
+        thirdPartyAuthContext: {
+          ...initialState.commonComponents.thirdPartyAuthContext,
+          providers: [{
+            ...ssoProvider,
+          }],
+        },
+      },
+    });
+
+    const loginPage = mount(reduxWrapper(<IntlLoginPage {...props} />));
+    expect(loginPage.text().includes('Or sign in with:')).toBe(true);
+    expect(loginPage.text().includes('Company or school credentials')).toBe(false);
+    expect(loginPage.text().includes('Institution/campus credentials')).toBe(false);
+
+    mergeConfig({
+      DISABLE_ENTERPRISE_LOGIN: '',
+    });
+  });
+
+  it('should not show sign-in header without Providers and secondary Providers (ENABLE ENTERPRISE LOGIN)', () => {
+    mergeConfig({
+      DISABLE_ENTERPRISE_LOGIN: '',
+    });
+
+    store = mockStore({
+      ...initialState,
+      commonComponents: {
+        ...initialState.commonComponents,
+        thirdPartyAuthContext: {
+          ...initialState.commonComponents.thirdPartyAuthContext,
+        },
+      },
+    });
+
+    const loginPage = mount(reduxWrapper(<IntlLoginPage {...props} />));
+    expect(loginPage.text().includes('Or sign in with:')).toBe(false);
+    expect(loginPage.text().includes('Company or school credentials')).toBe(false);
+    expect(loginPage.text().includes('Institution/campus credentials')).toBe(false);
+  });
+
+  it('should not show sign-in header without Providers and secondary Providers (DISABLE ENTERPRISE LOGIN)', () => {
+    mergeConfig({
+      DISABLE_ENTERPRISE_LOGIN: true,
+    });
+
+    store = mockStore({
+      ...initialState,
+      commonComponents: {
+        ...initialState.commonComponents,
+        thirdPartyAuthContext: {
+          ...initialState.commonComponents.thirdPartyAuthContext,
+        },
+      },
+    });
+
+    const loginPage = mount(reduxWrapper(<IntlLoginPage {...props} />));
+    expect(loginPage.text().includes('Or sign in with:')).toBe(false);
+    expect(loginPage.text().includes('Company or school credentials')).toBe(false);
+    expect(loginPage.text().includes('Institution/campus credentials')).toBe(false);
+
+    mergeConfig({
+      DISABLE_ENTERPRISE_LOGIN: '',
+    });
+  });
+
+  it('should show sign-in header with secondary Providers and without Providers', () => {
+    mergeConfig({
+      DISABLE_ENTERPRISE_LOGIN: true,
+    });
+
+    store = mockStore({
+      ...initialState,
+      commonComponents: {
+        ...initialState.commonComponents,
+        thirdPartyAuthContext: {
+          ...initialState.commonComponents.thirdPartyAuthContext,
+          secondaryProviders: [{
+            ...secondaryProviders,
+          }],
+        },
+      },
+    });
+
+    const loginPage = mount(reduxWrapper(<IntlLoginPage {...props} />));
+    expect(loginPage.text().includes('Or sign in with:')).toBe(true);
+    expect(loginPage.text().includes('Institution/campus credentials')).toBe(true);
+
+    mergeConfig({
+      DISABLE_ENTERPRISE_LOGIN: '',
+    });
+  });
+
+  it('should show sign-in header with Providers and secondary Providers', () => {
+    mergeConfig({
+      DISABLE_ENTERPRISE_LOGIN: true,
+    });
+
+    store = mockStore({
+      ...initialState,
+      commonComponents: {
+        ...initialState.commonComponents,
+        thirdPartyAuthContext: {
+          ...initialState.commonComponents.thirdPartyAuthContext,
+          providers: [{
+            ...ssoProvider,
+          }],
+          secondaryProviders: [{
+            ...secondaryProviders,
+          }],
+        },
+      },
+    });
+
+    const loginPage = mount(reduxWrapper(<IntlLoginPage {...props} />));
+    expect(loginPage.text().includes('Or sign in with:')).toBe(true);
+    expect(loginPage.text().includes('Company or school credentials')).toBe(false);
+    expect(loginPage.text().includes('Institution/campus credentials')).toBe(true);
+
+    mergeConfig({
+      DISABLE_ENTERPRISE_LOGIN: '',
+    });
+  });
+
   // ******** test alert messages ********
 
   it('should match login error message', () => {


### PR DESCRIPTION
### Description

A case was found when providers were displayed in authentication and there was no header for this block **"Or sign in with"**.
![Screen_26](https://user-images.githubusercontent.com/98233552/219125431-bfc2f428-823b-42ef-b986-6bf5588a36f3.png)
This case occurred when there was such a combination [in this condition](https://github.com/openedx/frontend-app-authn/blob/ee6a6f0d2d60b41a677f4efa3f2942251aa37754/src/login/LoginPage.jsx#L173): **isEnterpriseLoginDisabled=true** (DISABLE_ENTERPRISE_LOGIN=true), **isSocialAuthActive=true** (Providers have been configured in admin), **isInstitutionAuthActive=false** (secondary Providers are not configured), currentProvider="" (current provider no selected).
I picked a combination that would allow displaying this title whenever this block exists. And also wrote tests for all these cases.

#### Demonstration of different cases with a fix:
**DISABLE_ENTERPRISE_LOGIN=true, Providers=not configured,  secondaryProviders=not configured, currentProvider=no Selected:**
![Screenshot from 2023-02-15 17-07-21](https://user-images.githubusercontent.com/98233552/219131011-50e06027-0387-4022-8347-5ce90d25bb0d.png)
**DISABLE_ENTERPRISE_LOGIN=true, Providers=configured,  secondaryProviders=not configured, currentProvider=no Selected:**
![Screenshot from 2023-02-15 17-08-05](https://user-images.githubusercontent.com/98233552/219131297-8b410ef5-533e-4ffc-9cfa-887af357f0f7.png)
**DISABLE_ENTERPRISE_LOGIN=true, Providers=configured,  secondaryProviders=configured, currentProvider=no Selected:**
![Screenshot from 2023-02-15 17-08-39](https://user-images.githubusercontent.com/98233552/219131580-1f208863-77ad-46d9-a8a6-bce6ee1614ff.png)
**DISABLE_ENTERPRISE_LOGIN=true, Providers=not configured,  secondaryProviders=configured, currentProvider=no Selected:**
![Screenshot from 2023-02-15 17-09-20](https://user-images.githubusercontent.com/98233552/219131799-88231c59-ba2d-4ff4-b81d-56b7d625d061.png)
**DISABLE_ENTERPRISE_LOGIN='', Providers=not configured,  secondaryProviders=not configured, currentProvider=no Selected:**
![Screenshot from 2023-02-15 17-07-21](https://user-images.githubusercontent.com/98233552/219132334-cc539396-3a75-4689-ab80-58acd00a100a.png)
**DISABLE_ENTERPRISE_LOGIN='', Providers=configured,  secondaryProviders=configured, currentProvider=no Selected:**
![Screenshot from 2023-02-15 17-20-35](https://user-images.githubusercontent.com/98233552/219132540-f55bc437-6bb3-4096-9f80-1c8aec3501db.png)
**currentProvider=Selected:**
![Screenshot from 2023-02-15 17-20-38](https://user-images.githubusercontent.com/98233552/219132847-6d88f068-131e-4461-9693-651f2354f1da.png)


#### Merge Checklist

* [x] Is there adequate test coverage for your changes?
