### PR TITLE
feat: displaying a support link on the welcome page

### DIFF
--- a/src/progressive-profiling/ProgressiveProfiling.jsx
+++ b/src/progressive-profiling/ProgressiveProfiling.jsx
@@ -180,18 +180,20 @@ const ProgressiveProfiling = (props) => {
           ) : null}
           <Form>
             {formFields}
-            <span className="progressive-profiling-support">
-              <Hyperlink
-                isInline
-                variant="muted"
-                destination={getConfig().AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK}
-                target="_blank"
-                showLaunchIcon={false}
-                onClick={() => (sendTrackEvent('edx.bi.welcome.page.support.link.clicked'))}
-              >
-                {intl.formatMessage(messages['optional.fields.information.link'])}
-              </Hyperlink>
-            </span>
+            {(getConfig().AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK) && (
+              <span className="progressive-profiling-support">
+                <Hyperlink
+                  isInline
+                  variant="muted"
+                  destination={getConfig().AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK}
+                  target="_blank"
+                  showLaunchIcon={false}
+                  onClick={() => (sendTrackEvent('edx.bi.welcome.page.support.link.clicked'))}
+                >
+                  {intl.formatMessage(messages['optional.fields.information.link'])}
+                </Hyperlink>
+              </span>
+            )}
             <div className="d-flex mt-4 mb-3">
               <StatefulButton
                 type="submit"

--- a/src/progressive-profiling/tests/ProgressiveProfiling.test.jsx
+++ b/src/progressive-profiling/tests/ProgressiveProfiling.test.jsx
@@ -104,6 +104,24 @@ describe('ProgressiveProfilingTests', () => {
     };
   });
 
+  it('not should display button "Learn more about how we use this information."', async () => {
+    mergeConfig({
+      AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK: '',
+    });
+    const progressiveProfilingPage = await getProgressiveProfilingPage();
+
+    expect(progressiveProfilingPage.find('a.pgn__hyperlink').exists()).toBeFalsy();
+  });
+
+  it('should display button "Learn more about how we use this information."', async () => {
+    mergeConfig({
+      AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK: 'http://localhost:1999/support',
+    });
+    const progressiveProfilingPage = await getProgressiveProfilingPage();
+
+    expect(progressiveProfilingPage.find('a.pgn__hyperlink').text()).toEqual('Learn more about how we use this information.');
+  });
+
   it('should render fields returned by backend api', async () => {
     const progressiveProfilingPage = await getProgressiveProfilingPage();
     expect(progressiveProfilingPage.find('#gender').exists()).toBeTruthy();


### PR DESCRIPTION
### Description

Not everyone in the community uses page support. This update adds the dependence of the link display on the welcome page on the presence of a non-empty variable AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK in the MFE settings.
By default `AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK='http://localhost:1999/welcome'`

#### Screenshots:

If AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK is empty:
![Screen_47](https://user-images.githubusercontent.com/98233552/222088281-a11f7237-9660-438c-bdeb-5ae93a4bb9fb.png)

If the AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK variable contains the address of the support page:
![Screen_48](https://user-images.githubusercontent.com/98233552/222088326-f4fac8e3-c100-4a14-abd7-905a3d225bd0.png)