### PR TITLE
feat: displaying a support link on the welcome page

### DIFF
--- a/src/welcome/ProgressiveProfiling.jsx
+++ b/src/welcome/ProgressiveProfiling.jsx
@@ -148,18 +148,20 @@ const ProgressiveProfiling = (props) => {
           ) : null}
           <Form>
             {formFields}
-            <span className="progressive-profiling-support">
-              <Hyperlink
-                isInline
-                variant="muted"
-                destination={getConfig().WELCOME_PAGE_SUPPORT_LINK}
-                target="_blank"
-                showLaunchIcon={false}
-                onClick={() => (sendTrackEvent('edx.bi.welcome.page.support.link.clicked'))}
-              >
-                {intl.formatMessage(messages['optional.fields.information.link'])}
-              </Hyperlink>
-            </span>
+            {(getConfig().WELCOME_PAGE_SUPPORT_LINK) && (
+              <span className="progressive-profiling-support">
+                <Hyperlink
+                  isInline
+                  variant="muted"
+                  destination={getConfig().WELCOME_PAGE_SUPPORT_LINK}
+                  target="_blank"
+                  showLaunchIcon={false}
+                  onClick={() => (sendTrackEvent('edx.bi.welcome.page.support.link.clicked'))}
+                >
+                  {intl.formatMessage(messages['optional.fields.information.link'])}
+                </Hyperlink>
+              </span>
+            )}
             <div className="d-flex mt-4 mb-3">
               <StatefulButton
                 type="submit"

--- a/src/welcome/tests/ProgressiveProfiling.test.jsx
+++ b/src/welcome/tests/ProgressiveProfiling.test.jsx
@@ -94,6 +94,24 @@ describe('ProgressiveProfilingTests', () => {
     };
   });
 
+  it('not should display button "Learn more about how we use this information."', async () => {
+    mergeConfig({
+      WELCOME_PAGE_SUPPORT_LINK: '',
+    });
+    const progressiveProfilingPage = await getProgressiveProfilingPage();
+
+    expect(progressiveProfilingPage.find('a.pgn__hyperlink').exists()).toBeFalsy();
+  });
+
+  it('should display button "Learn more about how we use this information."', async () => {
+    mergeConfig({
+      WELCOME_PAGE_SUPPORT_LINK: 'http://localhost:1999/support',
+    });
+    const progressiveProfilingPage = await getProgressiveProfilingPage();
+
+    expect(progressiveProfilingPage.find('a.pgn__hyperlink').text()).toEqual('Learn more about how we use this information.');
+  });
+
   it('should render fields returned by backend api', async () => {
     const progressiveProfilingPage = await getProgressiveProfilingPage();
     expect(progressiveProfilingPage.find('#gender').exists()).toBeTruthy();


### PR DESCRIPTION
### Description
This is the [backport from the master](https://github.com/openedx/frontend-app-authn/pull/762)
Not everyone in the community uses page support. This update adds the dependence of the link display on the welcome page on the presence of a non-empty variable WELCOME_PAGE_SUPPORT_LINK in the MFE settings.
By default `WELCOME_PAGE_SUPPORT_LINK='http://localhost:1999/welcome'`

#### Screenshots:

If WELCOME_PAGE_SUPPORT_LINK is empty:
![Screen_47](https://user-images.githubusercontent.com/98233552/222111138-d800cf65-d912-4375-b1b9-b7df3db4958f.png)

If the WELCOME_PAGE_SUPPORT_LINK variable contains the address of the support page:
![Screen_48](https://user-images.githubusercontent.com/98233552/222111162-94f30866-a7f9-46e0-b23d-5f24119bf9cc.png)