### PR TITLE
fix: bottom padding missing unit

### DIFF
--- a/src/recommendations/RecommendationsPage.jsx
+++ b/src/recommendations/RecommendationsPage.jsx
@@ -91,7 +91,7 @@ const RecommendationsPage = (props) => {
           { siteName: getConfig().SITE_NAME })}
         </title>
       </Helmet>
-      <div className="d-flex flex-column vh-100">
+      <div className="d-flex flex-column vh-100 bg-light-200">
         <div className="mb-2">
           <div className="col-md-12 small-screen-top-stripe medium-screen-top-stripe extra-large-screen-top-stripe" />
           <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>

--- a/src/sass/_recommendations_page.scss
+++ b/src/sass/_recommendations_page.scss
@@ -1,6 +1,6 @@
 .card-list {
   padding-left: 0.0625rem;
-  padding-bottom: 0.125;
+  padding-bottom: 0.125rem;
   @include media-breakpoint-down(xl) {
     overflow-x: scroll;
     overflow-y: hidden;


### PR DESCRIPTION
### Description

Bottom padding was missing the unit. 
Ticket: https://2u-internal.atlassian.net/browse/VAN-1324

#### Screenshots/sandbox (optional):

|Before|After|
|-------|-----|
| <img width="770" alt="Screenshot 2023-03-01 at 5 28 27 PM" src="https://user-images.githubusercontent.com/40633976/222140282-5708b403-7b3c-4a2f-b9d4-66385694dc2b.png">|<img width="770" alt="Screenshot 2023-03-01 at 5 57 07 PM" src="https://user-images.githubusercontent.com/40633976/222145802-f11d0060-474c-41bb-a2b4-17a455ef196b.png">
|
