### PR TITLE
Card banner image is not centered aligned

### DIFF
--- a/src/sass/_recommendations_page.scss
+++ b/src/sass/_recommendations_page.scss
@@ -39,6 +39,7 @@
 
   .pgn__card-image-cap {
     height: 6.5rem;
+    // Property that center the image
     object-position: top;
   }
 

--- a/src/sass/_recommendations_page.scss
+++ b/src/sass/_recommendations_page.scss
@@ -39,6 +39,7 @@
 
   .pgn__card-image-cap {
     height: 6.5rem;
+    object-position: top;
   }
 
   .pgn__card-header-title-md {


### PR DESCRIPTION

VAN-1325

### Description

Post recommendation card's banner image was not centered aligned. Now added the object position property to make centered so that it looks like what we have in edx.org page.

#### How Has This Been Tested?

Tested locally 