### PR TITLE
fix: country dropdown issue on safari

### DIFF
--- a/src/register/registrationFields/CountryField.jsx
+++ b/src/register/registrationFields/CountryField.jsx
@@ -54,6 +54,10 @@ const CountryField = (props) => {
           value={countryName}
           key={country[COUNTRY_CODE_KEY]}
           onClick={(event) => onBlurHandler(event, true, countryName)}
+          /* This event will prevent the blur event to be fired,
+           as blur event is having higher priority than click event and restricts the click event.
+          */
+          onMouseDown={(event) => event.preventDefault()}
         >
           {countryName.length > 30 ? countryName.substring(0, 30).concat('...') : countryName}
         </button>


### PR DESCRIPTION
VAN-1317

### Description
On Safari browser country dropdown field is not functional so we have added the onMuseDown event for default prevention.