### PR TITLE
fix: make identify call to pass missing user_id

### DIFF
--- a/src/progressive-profiling/ProgressiveProfiling.jsx
+++ b/src/progressive-profiling/ProgressiveProfiling.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 
 import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
-import { sendPageEvent, sendTrackEvent } from '@edx/frontend-platform/analytics';
+import { identifyAuthenticatedUser, sendPageEvent, sendTrackEvent } from '@edx/frontend-platform/analytics';
 import {
   AxiosJwtAuthService,
   configure as configureAuth,
@@ -64,9 +64,10 @@ const ProgressiveProfiling = (props) => {
 
     if (registrationResponse) {
       setRegistrationResult(registrationResponse);
+      identifyAuthenticatedUser(authenticatedUser?.userId);
       sendPageEvent('login_and_registration', 'welcome');
     }
-  }, [DASHBOARD_URL, registrationResponse]);
+  }, [authenticatedUser, DASHBOARD_URL, registrationResponse]);
 
   useEffect(() => {
     if (registrationResponse) {

--- a/src/progressive-profiling/tests/ProgressiveProfiling.test.jsx
+++ b/src/progressive-profiling/tests/ProgressiveProfiling.test.jsx
@@ -27,6 +27,7 @@ jest.mock('@edx/frontend-platform/logging');
 
 analytics.sendTrackEvent = jest.fn();
 analytics.sendPageEvent = jest.fn();
+analytics.identifyAuthenticatedUser = jest.fn();
 logging.getLoggingService = jest.fn();
 
 auth.configure = jest.fn();
@@ -125,6 +126,11 @@ describe('ProgressiveProfilingTests', () => {
   it('should render fields returned by backend api', async () => {
     const progressiveProfilingPage = await getProgressiveProfilingPage();
     expect(progressiveProfilingPage.find('#gender').exists()).toBeTruthy();
+  });
+
+  it('should make identify call to segment on progressive profiling page', async () => {
+    await getProgressiveProfilingPage();
+    expect(analytics.identifyAuthenticatedUser).toHaveBeenCalled();
   });
 
   it('should submit user profile details on form submission', async () => {


### PR DESCRIPTION
This pull request addresses an issue where user_ids are missing from welcome page events due to an in-page redirect. Now, capturing user_id after registration by making a segment identify call.

Ticket: [VAN-1262](https://2u-internal.atlassian.net/browse/VAN-1262)