### PR TITLE
fix: Update the browser title for progressive profiling page

### DIFF
--- a/src/progressive-profiling/messages.jsx
+++ b/src/progressive-profiling/messages.jsx
@@ -3,7 +3,7 @@ import { defineMessages } from '@edx/frontend-platform/i18n';
 const messages = defineMessages({
   'progressive.profiling.page.title': {
     id: 'progressive.profiling.page.title',
-    defaultMessage: 'Optional Fields | {siteName}',
+    defaultMessage: 'Welcome | {siteName}',
     description: 'progressive profiling page title',
   },
   'progressive.profiling.page.heading': {


### PR DESCRIPTION
### Description

Update the browser title for the progressive profiling page on Authn.
### https://2u-internal.atlassian.net/browse/VAN-1337



#### Screenshots/sandbox (optional):

|Before|After|
|-------|-----|
|<img width="1397" alt="Screenshot 2023-03-20 at 4 50 51 PM" src="https://user-images.githubusercontent.com/7627421/226332924-2e2b589d-0e7f-4ed7-b6fb-0c4d09c3a37b.png">|<img width="1317" alt="Screenshot 2023-03-20 at 4 50 31 PM" src="https://user-images.githubusercontent.com/7627421/226332940-12b657b5-e885-48a0-94b0-922bd6d03dd7.png">|


