### PR TITLE
fix: Update tests to check identify calls count

### DIFF
--- a/src/progressive-profiling/tests/ProgressiveProfiling.test.jsx
+++ b/src/progressive-profiling/tests/ProgressiveProfiling.test.jsx
@@ -129,10 +129,10 @@ describe('ProgressiveProfilingTests', () => {
   });
 
   it('should make identify call to segment on progressive profiling page', async () => {
-    auth.getAuthenticatedUser = jest.fn(() => ({ userId: 3, username: 'abc123' }));
+    auth.getAuthenticatedUser = jest.fn(() => ({ userId: 123, username: 'abc123' }));
     await getProgressiveProfilingPage();
-    expect(analytics.identifyAuthenticatedUser).toHaveBeenCalledWith(3);
-    expect(analytics.identifyAuthenticatedUser).toHaveBeenCalled();
+    expect(analytics.identifyAuthenticatedUser).toHaveBeenCalledWith(123);
+    expect(analytics.identifyAuthenticatedUser).toHaveBeenCalledTimes(1);
   });
 
   it('should submit user profile details on form submission', async () => {


### PR DESCRIPTION
Update tests that verify we're not double-calling segment identify now.

Related Ticket: [VAN-1262](https://2u-internal.atlassian.net/browse/VAN-1262)