### PR TITLE
fix: fix recommendations viewed event count anomly

### DIFF
--- a/src/progressive-profiling/ProgressiveProfiling.jsx
+++ b/src/progressive-profiling/ProgressiveProfiling.jsx
@@ -75,14 +75,14 @@ const ProgressiveProfiling = (props) => {
   }, [authenticatedUser, registrationResponse]);
 
   useEffect(() => {
-    if (registrationResponse) {
+    if (registrationResponse && authenticatedUser?.userId) {
       const queryParams = getAllPossibleQueryParams(registrationResponse.redirectUrl);
       if (enablePersonalizedRecommendations && !('enrollment_action' in queryParams)) {
-        const userIdStr = authenticatedUser?.userId.toString();
+        const userIdStr = authenticatedUser.userId.toString();
         const showRecommendations = activateRecommendationsExperiment(userIdStr);
         setShowRecommendationsPage(showRecommendations);
         if (!showRecommendations) {
-          trackRecommendationsViewed([], true, authenticatedUser?.userId);
+          trackRecommendationsViewed([], true, authenticatedUser.userId);
         }
       }
     }

--- a/src/recommendations/RecommendationsPage.jsx
+++ b/src/recommendations/RecommendationsPage.jsx
@@ -24,6 +24,7 @@ const RecommendationsPage = (props) => {
 
   const [isLoading, setIsLoading] = useState(true);
   const [recommendations, setRecommendations] = useState([]);
+  const [algoliaRecommendations, setAlgoliaRecommendations] = useState([]);
   const educationLevel = EDUCATION_LEVEL_MAPPING[location.state?.educationLevel];
 
   useEffect(() => {
@@ -35,6 +36,7 @@ const RecommendationsPage = (props) => {
           ...course,
           courseKey: convertCourseRunKeytoCourseKey(course.activeRunKey),
         }));
+        setAlgoliaRecommendations(coursesWithKeys.slice(0, RECOMMENDATIONS_COUNT));
 
         if (coursesWithKeys.length >= RECOMMENDATIONS_COUNT) {
           setRecommendations(coursesWithKeys.slice(0, RECOMMENDATIONS_COUNT));
@@ -55,11 +57,16 @@ const RecommendationsPage = (props) => {
           setRecommendations(generalRecommendations.slice(0, RECOMMENDATIONS_COUNT));
           setIsLoading(false);
         });
-      // We only want to track the recommendations returned by Algolia
-      const courseKeys = coursesWithKeys.map(course => course.courseKey);
-      trackRecommendationsViewed(courseKeys.slice(0, RECOMMENDATIONS_COUNT), false, userId);
     }
   }, [registrationResponse, DASHBOARD_URL, educationLevel, userId]);
+
+  useEffect(() => {
+    if (!isLoading) {
+      // We only want to track the recommendations returned by Algolia
+      const courseKeys = algoliaRecommendations.map(course => course.courseKey);
+      trackRecommendationsViewed(courseKeys, false, userId);
+    }
+  }, [isLoading, algoliaRecommendations, userId]);
 
   if (!registrationResponse) {
     global.location.assign(DASHBOARD_URL);


### PR DESCRIPTION
### Description

This PR fixes two anomalies with welcome page recommendations viewed event

1. Recommendations viewed event was being sent two times for original variation (one without user id and one with user id)
2. Recommendations viewed event was not having course keys for experiment variation

#### How Has This Been Tested?

Tested locally

