### PR TITLE
fix: pass user id as string in optimizely track event

### DIFF
--- a/src/progressive-profiling/ProgressiveProfiling.jsx
+++ b/src/progressive-profiling/ProgressiveProfiling.jsx
@@ -83,7 +83,7 @@ const ProgressiveProfiling = (props) => {
         const showRecommendations = variation === RECOMMENDATIONS_EXP_VARIATION;
 
         trackRecommendationsGroup(variation, authenticatedUser.userId);
-        trackRecommendationViewedOptimizely(authenticatedUser.userId);
+        trackRecommendationViewedOptimizely(userIdStr);
         setShowRecommendationsPage(showRecommendations);
         if (!showRecommendations) {
           trackRecommendationsViewed([], true, authenticatedUser.userId);

--- a/src/recommendations/optimizelyExperiment.js
+++ b/src/recommendations/optimizelyExperiment.js
@@ -12,7 +12,7 @@ export const eventNames = {
   * Activate the post registration recommendations optimizely experiment
   * and return the true if the user is in variation else false.
   * @param  {String} userId  user id of authenticated user.
-  * @return {boolean} true if the user is in variation else false
+  * @return {string} true if the user is in variation else false
 */
 const activateRecommendationsExperiment = (userId) => optimizelyInstance.activate(RECOMMENDATIONS_EXP_KEY, userId);
 


### PR DESCRIPTION
### Description

pass user id as string in optimizely track event

#### How Has This Been Tested?

Tested locally

