### PR TITLE
chore: downgrade frontend-platform version from 3.6.1 to 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
         "@edx/frontend-component-cookie-policy-banner": "2.2.2",
-        "@edx/frontend-platform": "3.6.1",
+        "@edx/frontend-platform": "3.6.0",
         "@edx/paragon": "20.28.4",
         "@fortawesome/fontawesome-svg-core": "6.2.1",
         "@fortawesome/free-brands-svg-icons": "6.2.1",
@@ -3641,9 +3641,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-3.6.1.tgz",
-      "integrity": "sha512-OEWlNeS32R3aG9bz1E66Ncs/6aiaupjG9z2e9UCY4U1CEySLfIC2QRk+1hUxUqL65bNM0Q/4DYC+2DJM/D5EXg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-3.6.0.tgz",
+      "integrity": "sha512-CGE4AGxH7YHYdAF0hFz3CdoJ+95Ffx5lsE4ZfukR+r6z6UWhYC+BQ9iNcsiQgXgvM2zqqvwdICxRI4F1ODx1iA==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -30934,9 +30934,9 @@
       }
     },
     "@edx/frontend-platform": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-3.6.1.tgz",
-      "integrity": "sha512-OEWlNeS32R3aG9bz1E66Ncs/6aiaupjG9z2e9UCY4U1CEySLfIC2QRk+1hUxUqL65bNM0Q/4DYC+2DJM/D5EXg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-3.6.0.tgz",
+      "integrity": "sha512-CGE4AGxH7YHYdAF0hFz3CdoJ+95Ffx5lsE4ZfukR+r6z6UWhYC+BQ9iNcsiQgXgvM2zqqvwdICxRI4F1ODx1iA==",
       "requires": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-component-cookie-policy-banner": "2.2.2",
-    "@edx/frontend-platform": "3.6.1",
+    "@edx/frontend-platform": "3.6.0",
     "@edx/paragon": "20.28.4",
     "@fortawesome/fontawesome-svg-core": "6.2.1",
     "@fortawesome/free-brands-svg-icons": "6.2.1",


### PR DESCRIPTION
The purpose of this pull request is to downgrade the **frontend-platform** version from `3.6.1` to `3.6.0`, as described in this [PR](https://github.com/openedx/frontend-platform/pull/462)