### PR TITLE
fix: issue of missing user_id on welcome page events

### DIFF
--- a/src/progressive-profiling/ProgressiveProfiling.jsx
+++ b/src/progressive-profiling/ProgressiveProfiling.jsx
@@ -70,11 +70,11 @@ const ProgressiveProfiling = (props) => {
   }, [DASHBOARD_URL, registrationResponse]);
 
   useEffect(() => {
-    if (registrationResponse && authenticatedUser?.userId) {
+    if (ready && authenticatedUser?.userId) {
       identifyAuthenticatedUser(authenticatedUser.userId);
       sendPageEvent('login_and_registration', 'welcome');
     }
-  }, [authenticatedUser, registrationResponse]);
+  }, [authenticatedUser, ready]);
 
   useEffect(() => {
     if (registrationResponse && authenticatedUser?.userId) {


### PR DESCRIPTION
This pull request resolves an issue where user_ids were missing from welcome page events because of an in-page redirect. To fix this, we are now capturing user_ids after registration by making a segment identify call.

Ticket: [VAN-1262](https://2u-internal.atlassian.net/browse/VAN-1262)