### PR TITLE
fix: window console warning

### DIFF
--- a/src/setupTest.js
+++ b/src/setupTest.js
@@ -39,3 +39,27 @@ window.ResizeObserver = ResizeObserver;
 window.scrollTo = (x, y) => {
   document.documentElement.scrollTop = y;
 };
+
+const location = new URL('https://authn.edx.org');
+location.assign = jest.fn();
+location.replace = jest.fn();
+location.reload = jest.fn();
+delete window.location;
+window.location = location;
+
+const localStorageMock = jest.fn(() => {
+  let store = {};
+  return {
+    getItem: (key) => (store[key] || null),
+    setItem: (key, value) => {
+      store[key] = value.toString();
+    },
+    clear: () => {
+      store = {};
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+  };
+})();
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });


### PR DESCRIPTION
- Remove console log warnings from SocialAuthProviders unit tests by mocking the location object.
- Mock localStorage.

VAN-1350
