### PR TITLE
fix: change keys to camelCase for mfe_context response

### DIFF
--- a/src/common-components/data/service.js
+++ b/src/common-components/data/service.js
@@ -1,4 +1,4 @@
-import { camelCaseObject, convertKeyNames, getConfig } from '@edx/frontend-platform';
+import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 // eslint-disable-next-line import/prefer-default-export
@@ -18,10 +18,8 @@ export async function getThirdPartyAuthContext(urlParams) {
       throw (e);
     });
   return {
-    fieldDescriptions: data.registration_fields || {},
-    optionalFields: data.optional_fields || {},
-    thirdPartyAuthContext: camelCaseObject(
-      convertKeyNames(data.context_data, { fullname: 'name' }),
-    ),
+    fieldDescriptions: data.registrationFields || data.registration_fields,
+    optionalFields: data.optionalFields || data.optional_fields,
+    thirdPartyAuthContext: data.contextData || data.context_data,
   };
 }


### PR DESCRIPTION
### Description

Since the `mfe_context` API response now uses camelCase instead of snake_case, the `camelCaseObject` method is no longer necessary and we can use the new camelCase keys directly in the front-end. Therefore, this PR modifies the keys used in the `mfe_context` API response accordingly.

Related Ticket: [VAN-1311](https://2u-internal.atlassian.net/browse/VAN-1311)

> Backend [PR](https://github.com/openedx/edx-platform/pull/31930)