### PR TITLE
fix: ripple effect of skip_registeration_form if country code is empty

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -190,21 +190,24 @@ const RegistrationPage = (props) => {
   }, [registrationErrorCode]);
 
   useEffect(() => {
-    if (backendCountryCode !== '') {
-      const selectedCountry = countryList.find(
-        (country) => (country[COUNTRY_CODE_KEY].toLowerCase() === backendCountryCode.toLowerCase()),
-      );
-      if (selectedCountry) {
-        setConfigurableFormFields(prevState => (
-          {
-            ...prevState,
-            country: {
-              countryCode: selectedCountry[COUNTRY_CODE_KEY], displayValue: selectedCountry[COUNTRY_DISPLAY_KEY],
-            },
-          }
-        ));
-      }
+    let countryCode = '';
+    let countryDisplayValue = '';
+
+    const selectedCountry = countryList.find(
+      (country) => (country[COUNTRY_CODE_KEY].toLowerCase() === backendCountryCode.toLowerCase()),
+    );
+    if (selectedCountry) {
+      countryCode = selectedCountry[COUNTRY_CODE_KEY];
+      countryDisplayValue = selectedCountry[COUNTRY_DISPLAY_KEY];
     }
+    setConfigurableFormFields(prevState => (
+      {
+        ...prevState,
+        country: {
+          countryCode, displayValue: countryDisplayValue,
+        },
+      }
+    ));
   }, [backendCountryCode, countryList]);
 
   /**


### PR DESCRIPTION
### Description

We are auto-submitting the registration form when skip_registeration_form is true and while submitting we get displayValue attribute of the country field which is set only when the country code is coming from the backend or the user set the country from the field.

But in the case when auto submitting and country code not coming, this attribute is not set which causes an exception.

#### How Has This Been Tested?

Tested locally

\