### PR TITLE
fix: Update eslint configuration and resolve linting errors and test …

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,7 +48,6 @@ module.exports = createConfig('eslint', {
       },
     ],
     'function-paren-newline': 'off',
-    'no-import-assign': 'off',
     'react/no-unstable-nested-components': 'off',
   },
 });

--- a/src/common-components/tests/UnAuthOnlyRoute.test.jsx
+++ b/src/common-components/tests/UnAuthOnlyRoute.test.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/function-component-definition */
 import React from 'react';
 
-import * as auth from '@edx/frontend-platform/auth';
+import { fetchAuthenticatedUser, getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { mount } from 'enzyme';
 
 import { UnAuthOnlyRoute } from '..';
@@ -10,7 +10,10 @@ import { LOGIN_PAGE } from '../../data/constants';
 
 import { MemoryRouter, BrowserRouter as Router, Switch } from 'react-router-dom';
 
-jest.mock('@edx/frontend-platform/auth');
+jest.mock('@edx/frontend-platform/auth', () => ({
+  getAuthenticatedUser: jest.fn(),
+  fetchAuthenticatedUser: jest.fn(),
+}));
 
 const RRD = require('react-router-dom');
 // Just render plain div with its children
@@ -44,20 +47,21 @@ describe('UnAuthOnlyRoute', () => {
       username: 'gonzo',
       other: 'data',
     };
-    auth.getAuthenticatedUser = jest.fn(() => user);
-    auth.fetchAuthenticatedUser = jest.fn(() => ({ then: () => auth.getAuthenticatedUser() }));
+
+    getAuthenticatedUser.mockReturnValue(user);
+    fetchAuthenticatedUser.mockReturnValueOnce(Promise.resolve(user));
 
     mount(routerWrapper());
 
-    expect(auth.fetchAuthenticatedUser).toBeCalledWith({ forceRefresh: true });
+    expect(fetchAuthenticatedUser).toBeCalledWith({ forceRefresh: true });
   });
 
   it('should have called with forceRefresh false', () => {
-    auth.getAuthenticatedUser = jest.fn(() => null);
-    auth.fetchAuthenticatedUser = jest.fn(() => ({ then: () => auth.getAuthenticatedUser() }));
+    getAuthenticatedUser.mockReturnValue(null);
+    fetchAuthenticatedUser.mockReturnValueOnce(Promise.resolve(null));
 
     mount(routerWrapper());
 
-    expect(auth.fetchAuthenticatedUser).toBeCalledWith({ forceRefresh: false });
+    expect(fetchAuthenticatedUser).toBeCalledWith({ forceRefresh: false });
   });
 });

--- a/src/forgot-password/tests/ForgotPasswordPage.test.jsx
+++ b/src/forgot-password/tests/ForgotPasswordPage.test.jsx
@@ -3,8 +3,6 @@ import { Provider } from 'react-redux';
 
 import CookiePolicyBanner from '@edx/frontend-component-cookie-policy-banner';
 import { mergeConfig } from '@edx/frontend-platform';
-import * as analytics from '@edx/frontend-platform/analytics';
-import * as auth from '@edx/frontend-platform/auth';
 import { configure, injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { mount } from 'enzyme';
 import { createMemoryHistory } from 'history';
@@ -17,10 +15,11 @@ import { PASSWORD_RESET } from '../../reset-password/data/constants';
 import { setForgotPasswordFormData } from '../data/actions';
 import ForgotPasswordPage from '../ForgotPasswordPage';
 
-jest.mock('@edx/frontend-platform/analytics');
+jest.mock('@edx/frontend-platform/analytics', () => ({
+  sendPageEvent: jest.fn(),
+  sendTrackEvent: jest.fn(),
+}));
 jest.mock('@edx/frontend-platform/auth');
-
-analytics.sendPageEvent = jest.fn();
 
 const IntlForgotPasswordPage = injectIntl(ForgotPasswordPage);
 const mockStore = configureStore();
@@ -51,7 +50,12 @@ describe('ForgotPasswordPage', () => {
 
   beforeEach(() => {
     store = mockStore(initialState);
-    auth.getAuthenticatedUser = jest.fn(() => ({ userId: 3, username: 'test-user' }));
+    jest.mock('@edx/frontend-platform/auth', () => ({
+      getAuthenticatedUser: jest.fn(() => ({
+        userId: 3,
+        username: 'test-user',
+      })),
+    }));
     configure({
       loggingService: { logError: jest.fn() },
       config: {

--- a/src/login/tests/LoginFailure.test.jsx
+++ b/src/login/tests/LoginFailure.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import * as auth from '@edx/frontend-platform/auth';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
@@ -20,8 +19,9 @@ import {
 } from '../data/constants';
 import LoginFailureMessage from '../LoginFailure';
 
-jest.mock('@edx/frontend-platform/auth');
-auth.getAuthService = jest.fn();
+jest.mock('@edx/frontend-platform/auth', () => ({
+  getAuthService: jest.fn(),
+}));
 
 const IntlLoginFailureMessage = injectIntl(LoginFailureMessage);
 

--- a/src/login/tests/LoginPage.test.jsx
+++ b/src/login/tests/LoginPage.test.jsx
@@ -3,8 +3,7 @@ import { Provider } from 'react-redux';
 
 import CookiePolicyBanner from '@edx/frontend-component-cookie-policy-banner';
 import { getConfig, mergeConfig } from '@edx/frontend-platform';
-import * as analytics from '@edx/frontend-platform/analytics';
-import * as auth from '@edx/frontend-platform/auth';
+import { sendPageEvent } from '@edx/frontend-platform/analytics';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
@@ -19,12 +18,13 @@ import { INTERNAL_SERVER_ERROR } from '../data/constants';
 import LoginFailureMessage from '../LoginFailure';
 import LoginPage from '../LoginPage';
 
-jest.mock('@edx/frontend-platform/analytics');
-jest.mock('@edx/frontend-platform/auth');
-
-analytics.sendTrackEvent = jest.fn();
-analytics.sendPageEvent = jest.fn();
-auth.getAuthService = jest.fn();
+jest.mock('@edx/frontend-platform/analytics', () => ({
+  sendPageEvent: jest.fn(),
+  sendTrackEvent: jest.fn(),
+}));
+jest.mock('@edx/frontend-platform/auth', () => ({
+  getAuthService: jest.fn(),
+}));
 
 const IntlLoginFailureMessage = injectIntl(LoginFailureMessage);
 const IntlLoginPage = injectIntl(LoginPage);
@@ -682,7 +682,7 @@ describe('LoginPage', () => {
 
   it('should send page event when login page is rendered', () => {
     mount(reduxWrapper(<IntlLoginPage {...props} />));
-    expect(analytics.sendPageEvent).toHaveBeenCalledWith('login_and_registration', 'login');
+    expect(sendPageEvent).toHaveBeenCalledWith('login_and_registration', 'login');
   });
 
   it('tests that form is only scrollable on form submission', () => {

--- a/src/recommendations/tests/RecommendationsPage.test.jsx
+++ b/src/recommendations/tests/RecommendationsPage.test.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import { getConfig, mergeConfig } from '@edx/frontend-platform';
-import * as analytics from '@edx/frontend-platform/analytics';
+import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import configureStore from 'redux-mock-store';
 
 import { DEFAULT_REDIRECT_URL } from '../../data/constants';
-import * as getPersonalizedRecommendations from '../data/service';
+import getPersonalizedRecommendations from '../data/service';
 import { trackRecommendationCardClickOptimizely } from '../optimizelyExperiment';
 import RecommendationsPage from '../RecommendationsPage';
 import { mockedGeneralRecommendations, mockedResponse } from './mockedData';
@@ -17,13 +17,16 @@ import { mockedGeneralRecommendations, mockedResponse } from './mockedData';
 const IntlRecommendationsPage = injectIntl(RecommendationsPage);
 const mockStore = configureStore();
 
-jest.mock('@edx/frontend-platform/analytics');
-jest.mock('../data/service');
+jest.mock('@edx/frontend-platform/analytics', () => ({
+  sendTrackEvent: jest.fn(),
+}));
+jest.mock('../data/service', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
 jest.mock('../optimizelyExperiment', () => ({
   trackRecommendationCardClickOptimizely: jest.fn(),
 }));
-
-analytics.sendTrackEvent = jest.fn();
 
 describe('RecommendationsPageTests', () => {
   mergeConfig({
@@ -72,10 +75,10 @@ describe('RecommendationsPageTests', () => {
       href: getConfig().BASE_URL,
       assign: jest.fn().mockImplementation((value) => { window.location.href = value; }),
     };
-    getPersonalizedRecommendations.default = jest.fn().mockImplementation(() => Promise.resolve([]));
+    getPersonalizedRecommendations.mockImplementation(() => Promise.resolve([]));
     await getRecommendationsPage({});
 
-    expect(getPersonalizedRecommendations.default).toHaveBeenCalledTimes(0);
+    expect(getPersonalizedRecommendations).toHaveBeenCalledTimes(0);
     expect(window.location.href).toEqual(DASHBOARD_URL);
   });
   it('redirects to dashboard if user click on skip button', async () => {
@@ -92,21 +95,21 @@ describe('RecommendationsPageTests', () => {
         },
       },
     };
-    getPersonalizedRecommendations.default = jest.fn().mockImplementation(() => Promise.resolve(mockedResponse));
+    getPersonalizedRecommendations.mockImplementation(() => Promise.resolve(mockedResponse));
     const recommendationsPage = await getRecommendationsPage(props);
     recommendationsPage.find('button').simulate('click');
     expect(window.location.href).toEqual(DASHBOARD_URL);
   });
 
   it('should call trackRecommendationCardClickOptimizely when card is clicked', async () => {
-    getPersonalizedRecommendations.default = jest.fn().mockImplementation(() => Promise.resolve(mockedResponse));
+    getPersonalizedRecommendations.mockImplementation(() => Promise.resolve(mockedResponse));
     const recommendationsPage = await getRecommendationsPage();
     recommendationsPage.find('.card-box').first().simulate('click');
     expect(trackRecommendationCardClickOptimizely).toHaveBeenCalledTimes(1);
   });
 
   it('should show loading state to user', async () => {
-    getPersonalizedRecommendations.default = jest.fn().mockImplementation(() => Promise.resolve(mockedResponse));
+    getPersonalizedRecommendations.mockImplementation(() => Promise.resolve(mockedResponse));
     await act(async () => {
       const recommendationsPage = mount(reduxWrapper(<IntlRecommendationsPage {...defaultProps} />));
       expect(recommendationsPage.find('.centered-align-spinner').exists()).toBeTruthy();
@@ -116,11 +119,12 @@ describe('RecommendationsPageTests', () => {
   it('should call getPersonalizedRecommendations', async () => {
     delete window.location;
     window.location = { assign: jest.fn() };
-    getPersonalizedRecommendations.default = jest.fn().mockImplementation(() => Promise.resolve([]));
+    getPersonalizedRecommendations.mockClear();
+    getPersonalizedRecommendations.mockImplementation(() => Promise.resolve([]));
     await getRecommendationsPage();
 
-    expect(getPersonalizedRecommendations.default).toHaveBeenCalledTimes(1);
-    expect(analytics.sendTrackEvent).toHaveBeenCalledWith(
+    expect(getPersonalizedRecommendations).toHaveBeenCalledTimes(1);
+    expect(sendTrackEvent).toHaveBeenCalledWith(
       'edx.bi.user.recommendations.viewed',
       {
         page: 'authn_recommendations',
@@ -133,14 +137,14 @@ describe('RecommendationsPageTests', () => {
   });
 
   it('should display recommendations returned by Algolia', async () => {
-    getPersonalizedRecommendations.default = jest.fn().mockImplementation(() => Promise.resolve(mockedResponse));
+    getPersonalizedRecommendations.mockImplementation(() => Promise.resolve(mockedResponse));
     const recommendationsPage = await getRecommendationsPage();
 
     expect(recommendationsPage.find('#course-recommendations').exists()).toBeTruthy();
   });
 
   it('should not display recommendations if error comes in while fetching the recommendations', async () => {
-    getPersonalizedRecommendations.default = jest.fn().mockImplementation(() => Promise.reject(mockedResponse));
+    getPersonalizedRecommendations.mockImplementation(() => Promise.reject(mockedResponse));
     const recommendationsPage = await getRecommendationsPage();
 
     expect(recommendationsPage.find('#recommendation-card').exists()).toBeFalsy();
@@ -149,7 +153,7 @@ describe('RecommendationsPageTests', () => {
   it('should redirect if recommended courses count is less than RECOMMENDATIONS_COUNT', async () => {
     delete window.location;
     window.location = { assign: jest.fn() };
-    getPersonalizedRecommendations.default = jest.fn().mockImplementation(() => Promise.resolve([mockedResponse[0]]));
+    getPersonalizedRecommendations.mockImplementation(() => Promise.resolve([mockedResponse[0]]));
     const recommendationsPage = await getRecommendationsPage();
 
     expect(recommendationsPage.find('#course-recommendations').exists()).toBeFalsy();
@@ -160,14 +164,14 @@ describe('RecommendationsPageTests', () => {
     mergeConfig({
       GENERAL_RECOMMENDATIONS: mockedGeneralRecommendations,
     });
-    getPersonalizedRecommendations.default = jest.fn().mockImplementation(() => Promise.resolve([]));
+    getPersonalizedRecommendations.mockImplementation(() => Promise.resolve([]));
     const recommendationsPage = await getRecommendationsPage();
 
     expect(recommendationsPage.find('#course-recommendations').exists()).toBeTruthy();
   });
 
   it('should display all owners for a course', async () => {
-    getPersonalizedRecommendations.default = jest.fn().mockImplementation(() => Promise.resolve(mockedResponse));
+    getPersonalizedRecommendations.mockImplementation(() => Promise.resolve(mockedResponse));
     const recommendationsPage = await getRecommendationsPage();
 
     expect(

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux';
 
 import CookiePolicyBanner from '@edx/frontend-component-cookie-policy-banner';
 import { getConfig, mergeConfig } from '@edx/frontend-platform';
-import * as analytics from '@edx/frontend-platform/analytics';
+import { sendPageEvent } from '@edx/frontend-platform/analytics';
 import {
   configure, getLocale, injectIntl, IntlProvider,
 } from '@edx/frontend-platform/i18n';
@@ -27,14 +27,14 @@ import {
 import RegistrationFailureMessage from '../RegistrationFailure';
 import RegistrationPage from '../RegistrationPage';
 
-jest.mock('@edx/frontend-platform/analytics');
+jest.mock('@edx/frontend-platform/analytics', () => ({
+  sendPageEvent: jest.fn(),
+  sendTrackEvent: jest.fn(),
+}));
 jest.mock('@edx/frontend-platform/i18n', () => ({
   ...jest.requireActual('@edx/frontend-platform/i18n'),
   getLocale: jest.fn(),
 }));
-
-analytics.sendTrackEvent = jest.fn();
-analytics.sendPageEvent = jest.fn();
 
 const IntlRegistrationPage = injectIntl(RegistrationPage);
 const IntlRegistrationFailure = injectIntl(RegistrationFailureMessage);
@@ -878,7 +878,7 @@ describe('RegistrationPage', () => {
 
     it('should send page event when register page is rendered', () => {
       mount(reduxWrapper(<IntlRegistrationPage {...props} />));
-      expect(analytics.sendPageEvent).toHaveBeenCalledWith('login_and_registration', 'register');
+      expect(sendPageEvent).toHaveBeenCalledWith('login_and_registration', 'register');
     });
 
     it('should populate form with pipeline user details', () => {

--- a/src/reset-password/tests/ResetPasswordPage.test.jsx
+++ b/src/reset-password/tests/ResetPasswordPage.test.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import CookiePolicyBanner from '@edx/frontend-component-cookie-policy-banner';
-import * as auth from '@edx/frontend-platform/auth';
 import { configure, injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { mount } from 'enzyme';
 import { createMemoryHistory } from 'history';
@@ -69,11 +68,13 @@ describe('ResetPasswordPage', () => {
       },
     });
 
-    auth.getHttpClient = jest.fn(() => ({
-      post: async () => ({
-        data: {},
-        catch: () => {},
-      }),
+    jest.mock('@edx/frontend-platform/auth', () => ({
+      getHttpClient: jest.fn(() => ({
+        post: async () => ({
+          data: {},
+          catch: () => {},
+        }),
+      })),
     }));
 
     store.dispatch = jest.fn(store.dispatch);


### PR DESCRIPTION
A recent [change](https://github.com/openedx/frontend-app-authn/pull/791) to the `eslint` version was introduced when updating the `frontend-platform` to `v12`, resulting in several linting errors. This PR aims to fix those errors. Specifically, this PR removes the `no-import-assign` rule from the [eslintrc.js](https://github.com/openedx/frontend-app-authn/blob/master/.eslintrc.js#L51) file, which was causing linting errors in the codebase.

In addition to updating the configuration, this PR also fixes various linting issues that were uncovered during testing. These fixes include updating import statements and removing unused imports. Additionally, tests were failing due to these linting issues, so this PR also addresses those test failures.

It is important to note that the `no-import-assign` rule was removed in `eslint v8.0.0`, which is the version used in this PR.

Ticket: [VAN-1357](https://2u-internal.atlassian.net/browse/VAN-1357)