### PR TITLE
fix: nested components in CountryField

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,5 @@ module.exports = createConfig('eslint', {
       },
     ],
     'function-paren-newline': 'off',
-    'react/no-unstable-nested-components': 'off',
   },
 });

--- a/src/register/data/constants.js
+++ b/src/register/data/constants.js
@@ -173,3 +173,6 @@ export const DEFAULT_TOP_LEVEL_DOMAINS = [
 
 export const COUNTRY_CODE_KEY = 'code';
 export const COUNTRY_DISPLAY_KEY = 'name';
+
+export const EXPAND_MORE_ICON = 'expand-more';
+export const EXPAND_LESS_ICON = 'expand-less';

--- a/src/register/registrationFields/CountryField.jsx
+++ b/src/register/registrationFields/CountryField.jsx
@@ -6,7 +6,9 @@ import { ExpandLess, ExpandMore } from '@edx/paragon/icons';
 import PropTypes from 'prop-types';
 
 import { FormGroup } from '../../common-components';
-import { COUNTRY_CODE_KEY, COUNTRY_DISPLAY_KEY } from '../data/constants';
+import {
+  COUNTRY_CODE_KEY, COUNTRY_DISPLAY_KEY, EXPAND_LESS_ICON, EXPAND_MORE_ICON,
+} from '../data/constants';
 import messages from '../messages';
 
 const CountryField = (props) => {
@@ -17,7 +19,7 @@ const CountryField = (props) => {
   const [errorMessage, setErrorMessage] = useState(props.errorMessage);
   const [dropDownItems, setDropDownItems] = useState([]);
   const [displayValue, setDisplayValue] = useState('');
-  const [trailingIcon, setTrailingIcon] = useState(null);
+  const [trailingIcon, setTrailingIcon] = useState(EXPAND_MORE_ICON);
 
   const onBlurHandler = (event, itemClicked = false, countryName = '') => {
     const { name } = event.target;
@@ -31,7 +33,7 @@ const CountryField = (props) => {
     if (props.onBlurHandler) {
       props.onBlurHandler({ target: { name: 'country', value: countryValue } });
     }
-    setTrailingIcon(<ExpandMoreButton />);
+    setTrailingIcon(EXPAND_MORE_ICON);
     setDropDownItems([]);
   };
 
@@ -67,7 +69,7 @@ const CountryField = (props) => {
   const onFocusHandler = (event) => {
     const { name, value } = event.target;
     setDropDownItems(getDropdownItems(name === 'country' ? value : displayValue));
-    setTrailingIcon(<ExpandLessButton />);
+    setTrailingIcon(EXPAND_LESS_ICON);
     setErrorMessage('');
     if (props.onFocusHandler) { props.onFocusHandler(event); }
   };
@@ -80,49 +82,19 @@ const CountryField = (props) => {
   };
 
   const handleOnClickOutside = () => {
-    setTrailingIcon(<ExpandMoreButton />);
+    setTrailingIcon(EXPAND_MORE_ICON);
     setDropDownItems([]);
   };
 
-  const handleExpandMore = () => {
-    setTrailingIcon(<ExpandLessButton />);
-    setDropDownItems(getDropdownItems());
+  const handleTrailingIconClick = () => {
+    if (trailingIcon === EXPAND_MORE_ICON) {
+      setDropDownItems(getDropdownItems());
+      setTrailingIcon(EXPAND_LESS_ICON);
+    } else {
+      setDropDownItems([]);
+      setTrailingIcon(EXPAND_MORE_ICON);
+    }
   };
-
-  const handleExpandLess = () => {
-    setTrailingIcon(<ExpandMoreButton />);
-    setDropDownItems([]);
-  };
-
-  const ExpandMoreButton = () => (
-    <IconButton
-      name="countryExpand"
-      size="sm"
-      variant="secondary"
-      alt="expand-more"
-      className="expand-more"
-      iconAs={Icon}
-      src={ExpandMore}
-      onBlur={() => {}}
-      onClick={handleExpandMore}
-      onFocus={() => {}}
-    />
-  );
-
-  const ExpandLessButton = () => (
-    <IconButton
-      name="countryExpand"
-      size="sm"
-      variant="secondary"
-      alt="expand-less"
-      className="expand-less"
-      iconAs={Icon}
-      src={ExpandLess}
-      onBlur={() => {}}
-      onClick={handleExpandLess}
-      onFocus={() => {}}
-    />
-  );
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -135,12 +107,6 @@ const CountryField = (props) => {
       document.removeEventListener('click', handleClickOutside, true);
     };
   }, []);
-
-  useEffect(() => {
-    if (!trailingIcon) {
-      setTrailingIcon(<ExpandMoreButton />);
-    }
-  }, [trailingIcon]);
 
   useEffect(() => {
     if (selectedCountry.displayValue) {
@@ -160,7 +126,19 @@ const CountryField = (props) => {
         autoComplete="chrome-off"
         className="mb-0"
         floatingLabel={formatMessage(messages['registration.country.label'])}
-        trailingElement={trailingIcon}
+        trailingElement={(
+          <IconButton
+            name="countryExpand"
+            size="sm"
+            variant="secondary"
+            alt="expand-dropdown"
+            iconAs={Icon}
+            src={trailingIcon === EXPAND_MORE_ICON ? ExpandMore : ExpandLess}
+            onBlur={() => {}}
+            onClick={handleTrailingIconClick}
+            onFocus={() => {}}
+          />
+        )}
         value={displayValue}
         errorMessage={errorMessage}
         handleChange={onChangeHandler}

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -1140,7 +1140,7 @@ describe('RegistrationPage', () => {
       registrationPage.find('button.btn-brand').simulate('click');
       expect(registrationPage.find('div[feedback-for="name"]').exists()).toBeTruthy();
 
-      registrationPage.find('button.expand-more').simulate('click');
+      registrationPage.find('button[name="countryExpand"]').simulate('click');
       registrationPage.find('button.dropdown-item').at(0).simulate('click', { target: { value: 'Pakistan', name: 'countryItem' } });
       expect(registrationPage.find('div[feedback-for="name"]').exists()).toBeTruthy();
     });


### PR DESCRIPTION
### Description

We were using nested components inside the the CountryField. Creating components inside components (nested components) will cause React to throw away the state of those nested components on each re-render of their parent. The reference to the same element changes on each re-render when defining components inside the render block. This leads to complete recreation of the current node and all its children. As a result the virtual DOM has to do extra unnecessary work.

#### JIRA

[VAN-1358](https://2u-internal.atlassian.net/browse/VAN-1358)

#### How Has This Been Tested?

- Tested locally
- Running the unit tests

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
