### PR TITLE
fix: remove conditional logic

### DIFF
--- a/.github/workflows/autoupdate-pull-request.yml
+++ b/.github/workflows/autoupdate-pull-request.yml
@@ -10,11 +10,7 @@ on:
 jobs:
   autoupdate:
     name: autoupdate
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.action == 'labeled' &&
-      github.event.label.name == 'autoupdate'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: docker://chinthakagodawita/autoupdate-action:v1
         env:


### PR DESCRIPTION
Description

Remove conditional logic from autoupdate label as it does not run on master push

How Has This Been Tested?
It will be tested on remotely 

Related to: https://2u-internal.atlassian.net/browse/VAN-1349

