### PR TITLE
chore: remove react-onclickoutside package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "react-dom": "16.14.0",
         "react-helmet": "6.1.0",
         "react-loading-skeleton": "3.2.0",
-        "react-onclickoutside": "6.13.0",
         "react-redux": "7.2.9",
         "react-responsive": "8.2.0",
         "react-router": "5.3.4",
@@ -22264,19 +22263,6 @@
       "integrity": "sha512-kN12x4Ud69jbksr2EdhYywAFeW4bPdvFQ9p3ID1OM/QeFjgwFSmSUY2a6P6uOb5ACzWp3ozY8C+7+04KR6+PHA==",
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
-    },
-    "node_modules/react-onclickoutside": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
-      "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==",
-      "funding": {
-        "type": "individual",
-        "url": "https://github.com/Pomax/react-onclickoutside/blob/master/FUNDING.md"
-      },
-      "peerDependencies": {
-        "react": "^15.5.x || ^16.x || ^17.x || ^18.x",
-        "react-dom": "^15.5.x || ^16.x || ^17.x || ^18.x"
       }
     },
     "node_modules/react-overlays": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "react-dom": "16.14.0",
     "react-helmet": "6.1.0",
     "react-loading-skeleton": "3.2.0",
-    "react-onclickoutside": "6.13.0",
     "react-redux": "7.2.9",
     "react-responsive": "8.2.0",
     "react-router": "5.3.4",


### PR DESCRIPTION
VAN-1380

### Description

`react-onclickoutside` was used in country dropdown field to catch outside click and close the dropdown but we changed its implementation and use onBlur event for this now therefore it is not needed anymore and can be removed.

PR in which it was added: https://github.com/openedx/frontend-app-authn/commit/5358538d2212d280b4694bf83505500d1042db6f

#### JIRA

[VAN-1380](https://2u-internal.atlassian.net/browse/VAN-1380)

#### How Has This Been Tested?

Tested locally


