### PR TITLE
chore: remove semver-regex package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "redux-thunk": "2.4.2",
         "regenerator-runtime": "0.13.11",
         "reselect": "4.1.7",
-        "semver-regex": "3.1.4",
         "universal-cookie": "4.0.4"
       },
       "devDependencies": {
@@ -23519,17 +23518,6 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/semver-regex": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
-      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/send": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "redux-thunk": "2.4.2",
     "regenerator-runtime": "0.13.11",
     "reselect": "4.1.7",
-    "semver-regex": "3.1.4",
     "universal-cookie": "4.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

`semver-regex` was a dependency to `"@edx/frontend-build"` which was not directly used in `frontend-app-authn` but it was pinned to fix security vulnerabilities in authn in this [PR](https://github.com/openedx/frontend-app-authn/pull/514/files).

The` semver-regex` was a dependency to `image-webpack-loader` which was replaced with `image-minimizer-webpack-plugin` hence removing semver-regex along with other dependencies of image-webpack-loader therefore it's no longer a concern. This security vulnerability is fixed in this PR https://github.com/openedx/frontend-build/pull/259/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519L16092

 We are on latest version `@edx/frontend-build": "12.8.10`  we can remove it from authn as well.

#### JIRA

[VAN-1382](https://2u-internal.atlassian.net/browse/VAN-1382)

#### How Has This Been Tested?

Tested locally

