### PR TITLE
chore: upgrade the query-string version to 7.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "fastest-levenshtein": "1.0.16",
         "form-urlencoded": "6.1.0",
         "prop-types": "15.8.1",
-        "query-string": "5.1.1",
+        "query-string": "7.1.3",
         "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-helmet": "6.1.0",
@@ -21633,16 +21633,28 @@
       }
     },
     "node_modules/query-string": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
       "dependencies": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "^0.2.2",
+        "filter-obj": "^1.1.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/query-string/node_modules/strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "fastest-levenshtein": "1.0.16",
     "form-urlencoded": "6.1.0",
     "prop-types": "15.8.1",
-    "query-string": "5.1.1",
+    "query-string": "7.1.3",
     "react": "16.14.0",
     "react-dom": "16.14.0",
     "react-helmet": "6.1.0",


### PR DESCRIPTION
This PR updates the `query-string` version to `7.1.3`. For more information about the changes included in this PR, please refer to the linked [ticket](https://2u-internal.atlassian.net/browse/VAN-1374). Additionally, there is a reference PR linked [here](https://github.com/openedx/frontend-app-authn/pull/846).