### PR TITLE
fix: import/no-cycle eslint issue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -48,6 +48,5 @@ module.exports = createConfig('eslint', {
       },
     ],
     'function-paren-newline': 'off',
-    'import/no-cycle': 'off',
   },
 });

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -6,7 +6,7 @@ import { Helmet } from 'react-helmet';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import {
-  Logistration, NotFoundPage, registerIcons, UnAuthOnlyRoute, Zendesk,
+  NotFoundPage, registerIcons, UnAuthOnlyRoute, Zendesk,
 } from './common-components';
 import configureStore from './data/configureStore';
 import {
@@ -20,6 +20,7 @@ import {
 } from './data/constants';
 import { updatePathWithQueryParams } from './data/utils';
 import { ForgotPasswordPage } from './forgot-password';
+import Logistration from './logistration/Logistration';
 import { ProgressiveProfiling } from './progressive-profiling';
 import { RecommendationsPage } from './recommendations';
 import { ResetPasswordPage } from './reset-password';

--- a/src/common-components/index.jsx
+++ b/src/common-components/index.jsx
@@ -11,5 +11,4 @@ export { default as saga } from './data/sagas';
 export { storeName } from './data/selectors';
 export { default as FormGroup } from './FormGroup';
 export { default as PasswordField } from './PasswordField';
-export { default as Logistration } from './Logistration';
 export { default as Zendesk } from './Zendesk';

--- a/src/logistration/Logistration.jsx
+++ b/src/logistration/Logistration.jsx
@@ -14,12 +14,12 @@ import { ChevronLeft } from '@edx/paragon/icons';
 import PropTypes from 'prop-types';
 import { Redirect } from 'react-router-dom';
 
-import { clearThirdPartyAuthContextErrorMessage } from './data/actions';
+import { BaseComponent } from '../base-component';
+import { clearThirdPartyAuthContextErrorMessage } from '../common-components/data/actions';
 import {
   tpaProvidersSelector,
-} from './data/selectors';
-import messages from './messages';
-import { BaseComponent } from '../base-component';
+} from '../common-components/data/selectors';
+import messages from '../common-components/messages';
 import { LOGIN_PAGE, REGISTER_PAGE } from '../data/constants';
 import { getTpaHint, getTpaProvider, updatePathWithQueryParams } from '../data/utils';
 import { LoginPage } from '../login';

--- a/src/logistration/Logistration.test.jsx
+++ b/src/logistration/Logistration.test.jsx
@@ -8,11 +8,11 @@ import { mount } from 'enzyme';
 import { MemoryRouter } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 
-import { COMPLETE_STATE, LOGIN_PAGE } from '../../data/constants';
-import { backupRegistrationForm } from '../../register/data/actions';
-import { clearThirdPartyAuthContextErrorMessage } from '../data/actions';
-import { RenderInstitutionButton } from '../InstitutionLogistration';
-import Logistration from '../Logistration';
+import Logistration from './Logistration';
+import { clearThirdPartyAuthContextErrorMessage } from '../common-components/data/actions';
+import { RenderInstitutionButton } from '../common-components/InstitutionLogistration';
+import { COMPLETE_STATE, LOGIN_PAGE } from '../data/constants';
+import { backupRegistrationForm } from '../register/data/actions';
 
 jest.mock('@edx/frontend-platform/analytics', () => ({
   sendPageEvent: jest.fn(),


### PR DESCRIPTION
VAN-1388

### Description

A recent [change](https://github.com/openedx/frontend-app-authn/pull/791) updated the version of `eslint-plugin-import` form `2.26.0 -> 2.27.5`
This change resulted in an `import/no-cycle error` linting error which is fixed in this PR.

**How this is fixed?**

We have a `common-components` directory containing components which are used by all other components in `frontend-app-authn`. The `Logistration` component was in `common-components` and it imports the `Login` and `Register` Pages. Inside the login and register pages, we are importing other components from `common-components` which caused an `import-cycle` dependency issue in authn. 

This PR moved the `Logistration` component from common components to a separate container. 

#### JIRA

[VAN-1388](https://2u-internal.atlassian.net/browse/VAN-1388)

#### How Has This Been Tested?

Tested all flows locally
