### PR TITLE
fix: eliminate the usage of OR operator in MFE context API

### DIFF
--- a/src/common-components/data/service.js
+++ b/src/common-components/data/service.js
@@ -1,4 +1,4 @@
-import { camelCaseObject, convertKeyNames, getConfig } from '@edx/frontend-platform';
+import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 // eslint-disable-next-line import/prefer-default-export
@@ -18,10 +18,8 @@ export async function getThirdPartyAuthContext(urlParams) {
       throw (e);
     });
   return {
-    fieldDescriptions: data.registrationFields || data.registration_fields || {},
-    optionalFields: data.optionalFields || data.optional_fields || {},
-    thirdPartyAuthContext: data.contextData || camelCaseObject(
-      convertKeyNames(data.context_data, { fullname: 'name' }),
-    ),
+    fieldDescriptions: data.registrationFields || {},
+    optionalFields: data.optionalFields || {},
+    thirdPartyAuthContext: data.contextData || {},
   };
 }


### PR DESCRIPTION
This PR removes the launch strategy logic code that was implemented to prevent the front-end from breaking while serializing the MFE context API response to camelCase on the back-end. Since both the front-end and back-end PRs have been deployed on production, the launch strategy logic code is no longer necessary.

> Related Ticket: [VAN-1311](https://2u-internal.atlassian.net/browse/VAN-1311)
