### PR TITLE
feat: use `atlas` in `make pull_translations`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 export TRANSIFEX_RESOURCE = frontend-app-authn
 transifex_langs = "ar,fr,es_419,zh_CN,pt,it,de,uk,ru,hi,fr_CA,it_IT,pt_PT,de_DE"
 
+intl_imports = ./node_modules/.bin/intl-imports.js
 transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
 transifex_input = $(i18n)/transifex_input.json
@@ -42,9 +43,22 @@ push_translations:
 	# Pushing comments to Transifex...
 	./node_modules/@edx/reactifex/bash_scripts/put_comments_v3.sh
 
+ifeq ($(OPENEDX_ATLAS_PULL),)
 # Pulls translations from Transifex.
 pull_translations:
 	tx pull -t -f --mode reviewed --languages=$(transifex_langs)
+else
+# Experimental: OEP-58 Pulls translations using atlas
+pull_translations:
+	rm -rf src/i18n/messages
+	mkdir src/i18n/messages
+	cd src/i18n/messages \
+	  && atlas pull --filter=$(transifex_langs) \
+	           translations/paragon/src/i18n/messages:paragon \
+	           translations/frontend-app-authn/src/i18n/messages:frontend-app-authn
+
+	$(intl_imports) paragon frontend-app-authn
+endif
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:

--- a/src/i18n/index.jsx
+++ b/src/i18n/index.jsx
@@ -1,3 +1,5 @@
+import { messages as paragonMessages } from '@edx/paragon';
+
 import arMessages from './messages/ar.json';
 import deMessages from './messages/de.json';
 import dedeCAMessages from './messages/de_DE.json';
@@ -14,7 +16,7 @@ import ukMessages from './messages/uk.json';
 import zhcnMessages from './messages/zh_CN.json';
 // no need to import en messages-- they are in the defaultMessage field
 
-const messages = {
+const appMessages = {
   ar: arMessages,
   'es-419': es419Messages,
   fr: frMessages,
@@ -31,4 +33,7 @@ const messages = {
   'pt-pt': ptptCAMessages,
 };
 
-export default messages;
+export default [
+  paragonMessages,
+  appMessages,
+];

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,10 +8,9 @@ import {
   APP_INIT_ERROR, APP_READY, initialize, mergeConfig, subscribe,
 } from '@edx/frontend-platform';
 import { ErrorPage } from '@edx/frontend-platform/react';
-import { messages as paragonMessages } from '@edx/paragon';
 
 import configuration from './config';
-import appMessages from './i18n';
+import messages from './i18n';
 import MainApp from './MainApp';
 
 subscribe(APP_READY, () => {
@@ -31,8 +30,5 @@ initialize({
       mergeConfig(configuration);
     },
   },
-  messages: [
-    appMessages,
-    paragonMessages,
-  ],
+  messages,
 });


### PR DESCRIPTION
feat: use `atlas` in `make pull_translations`

Changes
-------
 - Move all i18n imports into `src/i18n/index.js` so `intl-imports.js` can    override it with latest translations
 - Add `atlas` into `make pull_translations` when `OPENEDX_ATLAS_PULL` environment variable is set.


Testing
-------
 - [x] Fix tests and lint rules
 - [x] Test pulled translations
 - [x] Quick QA for translated content: <details><summary>Screenshot</summary>![image](https://user-images.githubusercontent.com/645156/236773387-7610cc4c-db1b-4a0c-b5c2-80c69a9be65e.png)</details> 

**Note:** I had to disable the Third-Party Auth form since it didn't work for me even on `master`.

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern. But before that, please know the strategy we're following to avoid breaking changes

**For Micro-frontends:**

 - Legacy hardcoded translations are kept into the repo.
 - Consolidate all i18n imports into `src/i18n/index.js`
 - Add `atlas` integration in `make pull_translations` but only if `OPENEDX_ATLAS_PULL` is set
 - Bump frontend-platform and use `intl-imports.js` to generate up to date import files
 - If translations is missing, they're added according to the latest Micro-frontend i18n pattern in par with https://github.com/openedx/frontend-template-application/


