### PR TITLE
fix: add departments in Zendesk widget

### DIFF
--- a/src/common-components/Zendesk.jsx
+++ b/src/common-components/Zendesk.jsx
@@ -16,6 +16,9 @@ const ZendeskHelp = () => {
       },
       chat: {
         suppress: false,
+        departments: {
+          enabled: ['account settings', 'billing and payments', 'certificates', 'deadlines', 'errors and technical issues', 'other', 'proctoring'],
+        },
       },
       contactForm: {
         ticketForms: [

--- a/src/common-components/tests/__snapshots__/Zendesk.test.jsx.snap
+++ b/src/common-components/tests/__snapshots__/Zendesk.test.jsx.snap
@@ -20,6 +20,17 @@ exports[`Zendesk Help should match login page third party auth alert message sna
         },
       },
       "chat": Object {
+        "departments": Object {
+          "enabled": Array [
+            "account settings",
+            "billing and payments",
+            "certificates",
+            "deadlines",
+            "errors and technical issues",
+            "other",
+            "proctoring",
+          ],
+        },
         "suppress": false,
       },
       "contactForm": Object {


### PR DESCRIPTION
Description:
Add departments list in Zendesk widget configurations

Related to: [VAN-1426](https://2u-internal.atlassian.net/browse/VAN-1426)

How it has been tested?
This is tested locally.

Before adding the departments:

<img width="1440" alt="Screenshot 2023-05-10 at 1 47 10 PM" src="https://github.com/openedx/frontend-app-authn/assets/12580995/554bddd6-029a-4e84-946e-16d162e68dac">

After adding the departments:

<img width="1440" alt="Screenshot 2023-05-10 at 1 08 31 PM" src="https://github.com/openedx/frontend-app-authn/assets/12580995/24203fe2-11aa-42dd-961a-869148d7f1ef">


