### PR TITLE
fix: avoid validations on blur event

### DIFF
--- a/src/register/ConfigurableRegistrationForm.jsx
+++ b/src/register/ConfigurableRegistrationForm.jsx
@@ -34,6 +34,7 @@ const ConfigurableRegistrationForm = (props) => {
     setFieldErrors,
     setFocusedField,
     setFormFields,
+    registrationEmbedded,
   } = props;
 
   let showTermsOfServiceAndHonorCode = false;
@@ -81,6 +82,9 @@ const ConfigurableRegistrationForm = (props) => {
       error = fieldDescriptions[name].error_message;
     } else if (name === 'confirm_email' && value !== email) {
       error = formatMessage(messages['email.do.not.match']);
+    }
+    if (registrationEmbedded) {
+      return;
     }
     setFocusedField(null);
     setFieldErrors(prevErrors => ({ ...prevErrors, [name]: error }));
@@ -216,10 +220,12 @@ ConfigurableRegistrationForm.propTypes = {
   setFieldErrors: PropTypes.func.isRequired,
   setFocusedField: PropTypes.func.isRequired,
   setFormFields: PropTypes.func.isRequired,
+  registrationEmbedded: PropTypes.bool,
 };
 
 ConfigurableRegistrationForm.defaultProps = {
   fieldDescriptions: {},
+  registrationEmbedded: false,
 };
 
 export default ConfigurableRegistrationForm;

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -411,6 +411,9 @@ const RegistrationPage = (props) => {
   };
 
   const handleOnBlur = (event) => {
+    if (registrationEmbedded) {
+      return;
+    }
     const { name, value } = event.target;
     const payload = {
       name: formFields.name,
@@ -599,6 +602,7 @@ const RegistrationPage = (props) => {
                 countryList={countryList}
                 email={formFields.email}
                 fieldErrors={errors}
+                registrationEmbedded={registrationEmbedded}
                 formFields={configurableFormFields}
                 setFieldErrors={setErrors}
                 setFormFields={setConfigurableFormFields}

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -250,6 +250,18 @@ describe('RegistrationPage', () => {
 
     // ******** test registration form validations ********
 
+    it('should not run validations on blur event when embedded variant is rendered', () => {
+      delete window.location;
+      window.location = { href: getConfig().BASE_URL.concat(REGISTER_PAGE), search: '?variant=embedded' };
+      const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
+
+      registrationPage.find('input#username').simulate('blur', { target: { value: '', name: 'username' } });
+      expect(registrationPage.find('div[feedback-for="username"]').exists()).toBeFalsy();
+
+      registrationPage.find('input[name="country"]').simulate('blur', { target: { value: '', name: 'country' } });
+      expect(registrationPage.find('div[feedback-for="country"]').exists()).toBeFalsy();
+    });
+
     it('should show error messages for required fields on empty form submission', () => {
       const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
       registrationPage.find('button.btn-brand').simulate('click');


### PR DESCRIPTION
Description:

When Authn is embedded in iframe then validations should not runs on blur event it should only run when button is clicked.

Its related to : [VAN-1481](https://2u-internal.atlassian.net/browse/VAN-1481)

Its has been tested locally.