### PR TITLE
fix: render embedded experience through pathname

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -6,7 +6,7 @@ import { Helmet } from 'react-helmet';
 import { Redirect, Route, Switch } from 'react-router-dom';
 
 import {
-  NotFoundPage, registerIcons, UnAuthOnlyRoute, Zendesk,
+  EmbeddedRegistrationRoute, NotFoundPage, registerIcons, UnAuthOnlyRoute, Zendesk,
 } from './common-components';
 import configureStore from './data/configureStore';
 import {
@@ -15,6 +15,7 @@ import {
   PAGE_NOT_FOUND,
   PASSWORD_RESET_CONFIRM,
   RECOMMENDATIONS,
+  REGISTER_EMBEDDED_PAGE,
   REGISTER_PAGE,
   RESET_PAGE,
 } from './data/constants';
@@ -23,7 +24,9 @@ import { ForgotPasswordPage } from './forgot-password';
 import Logistration from './logistration/Logistration';
 import { ProgressiveProfiling } from './progressive-profiling';
 import { RecommendationsPage } from './recommendations';
+import { RegistrationPage } from './register';
 import { ResetPasswordPage } from './reset-password';
+
 import './index.scss';
 
 registerIcons();
@@ -38,6 +41,11 @@ const MainApp = () => (
       <Route exact path="/">
         <Redirect to={updatePathWithQueryParams(REGISTER_PAGE)} />
       </Route>
+      <EmbeddedRegistrationRoute
+        exact
+        path={REGISTER_EMBEDDED_PAGE}
+        component={RegistrationPage}
+      />
       <UnAuthOnlyRoute exact path={LOGIN_PAGE} render={() => <Logistration selectedPage={LOGIN_PAGE} />} />
       <UnAuthOnlyRoute exact path={REGISTER_PAGE} component={Logistration} />
       <UnAuthOnlyRoute exact path={RESET_PAGE} component={ForgotPasswordPage} />

--- a/src/common-components/EmbeddedRegistrationRoute.jsx
+++ b/src/common-components/EmbeddedRegistrationRoute.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import PropTypes from 'prop-types';
+import { Redirect, Route } from 'react-router-dom';
+
+import { PAGE_NOT_FOUND } from '../data/constants';
+import { isHostAvailableInQueryParams } from '../data/utils';
+
+/**
+ * This wrapper redirects the requester to embedded register page only if host
+ * query param is present.
+ */
+const EmbeddedRegistrationRoute = (props) => {
+  const registrationEmbedded = isHostAvailableInQueryParams();
+
+  // Show registration page for embedded experience even if the user is authenticated
+  if (registrationEmbedded) {
+    return <Route {...props} />;
+  }
+
+  return <Redirect to={PAGE_NOT_FOUND} />;
+};
+
+EmbeddedRegistrationRoute.propTypes = {
+  path: PropTypes.string.isRequired,
+};
+
+export default EmbeddedRegistrationRoute;

--- a/src/common-components/RedirectLogistration.jsx
+++ b/src/common-components/RedirectLogistration.jsx
@@ -41,7 +41,10 @@ const RedirectLogistration = (props) => {
       setCookie('van-504-returning-user', true);
 
       if (registrationEmbedded) {
-        window.parent.postMessage({ action: REDIRECT, redirectUrl: getConfig().POST_REGISTRATION_REDIRECT_URL }, host);
+        window.parent.postMessage({
+          action: REDIRECT,
+          redirectUrl: getConfig().POST_REGISTRATION_REDIRECT_URL,
+        }, host);
         return null;
       }
       const registrationResult = { redirectUrl: finalRedirectUrl, success };

--- a/src/common-components/UnAuthOnlyRoute.jsx
+++ b/src/common-components/UnAuthOnlyRoute.jsx
@@ -6,9 +6,8 @@ import PropTypes from 'prop-types';
 import { Route } from 'react-router-dom';
 
 import {
-  DEFAULT_REDIRECT_URL, REGISTER_PAGE,
+  DEFAULT_REDIRECT_URL,
 } from '../data/constants';
-import { isRegistrationEmbedded } from '../data/utils';
 
 /**
  * This wrapper redirects the requester to our default redirect url if they are
@@ -17,20 +16,13 @@ import { isRegistrationEmbedded } from '../data/utils';
 const UnAuthOnlyRoute = (props) => {
   const [authUser, setAuthUser] = useState({});
   const [isReady, setIsReady] = useState(false);
-  const registrationEmbedded = isRegistrationEmbedded() && props.path === REGISTER_PAGE;
 
   useEffect(() => {
-    if (registrationEmbedded) { return; }
     fetchAuthenticatedUser({ forceRefresh: !!getAuthenticatedUser() }).then((authenticatedUser) => {
       setAuthUser(authenticatedUser);
       setIsReady(true);
     });
-  }, [registrationEmbedded]);
-
-  // Show registration page for embedded experience even if the user is authenticated
-  if (registrationEmbedded) {
-    return <Route {...props} />;
-  }
+  }, []);
 
   if (isReady) {
     if (authUser && authUser.username) {

--- a/src/common-components/index.jsx
+++ b/src/common-components/index.jsx
@@ -1,5 +1,6 @@
 export { default as RedirectLogistration } from './RedirectLogistration';
 export { default as registerIcons } from './RegisterFaIcons';
+export { default as EmbeddedRegistrationRoute } from './EmbeddedRegistrationRoute';
 export { default as UnAuthOnlyRoute } from './UnAuthOnlyRoute';
 export { default as NotFoundPage } from './NotFoundPage';
 export { default as SocialAuthProviders } from './SocialAuthProviders';

--- a/src/common-components/tests/EmbeddedRegistrationRoute.test.jsx
+++ b/src/common-components/tests/EmbeddedRegistrationRoute.test.jsx
@@ -1,0 +1,67 @@
+/* eslint-disable import/no-import-module-exports */
+/* eslint-disable react/function-component-definition */
+import React from 'react';
+
+import { getConfig } from '@edx/frontend-platform';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+
+import { REGISTER_EMBEDDED_PAGE } from '../../data/constants';
+import EmbeddedRegistrationRoute from '../EmbeddedRegistrationRoute';
+
+import { MemoryRouter, BrowserRouter as Router, Switch } from 'react-router-dom';
+
+const RRD = require('react-router-dom');
+// Just render plain div with its children
+// eslint-disable-next-line react/prop-types
+RRD.BrowserRouter = ({ children }) => <div>{ children }</div>;
+module.exports = RRD;
+
+const TestApp = () => (
+  <Router>
+    <div>
+      <Switch>
+        <EmbeddedRegistrationRoute path={REGISTER_EMBEDDED_PAGE} render={() => (<span>Embedded Register Page</span>)} />
+      </Switch>
+    </div>
+  </Router>
+);
+
+describe('EmbeddedRegistrationRoute', () => {
+  const routerWrapper = () => (
+    <MemoryRouter initialEntries={[REGISTER_EMBEDDED_PAGE]}>
+      <TestApp />
+    </MemoryRouter>
+  );
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not render embedded register page if host query param is not available in the url', async () => {
+    let embeddedRegistrationPage = null;
+
+    await act(async () => {
+      embeddedRegistrationPage = await mount(routerWrapper());
+    });
+
+    expect(embeddedRegistrationPage.find('span').exists()).toBeFalsy();
+  });
+
+  it('should render embedded register page if host query param is available in the url (embedded)', async () => {
+    delete window.location;
+    window.location = {
+      href: getConfig().BASE_URL.concat(REGISTER_EMBEDDED_PAGE),
+      search: '?host=http://localhost/host-websit',
+    };
+
+    let embeddedRegistrationPage = null;
+
+    await act(async () => {
+      embeddedRegistrationPage = await mount(routerWrapper());
+    });
+
+    expect(embeddedRegistrationPage.find('span').exists()).toBeTruthy();
+    expect(embeddedRegistrationPage.find('span').text()).toBe('Embedded Register Page');
+  });
+});

--- a/src/common-components/tests/UnAuthOnlyRoute.test.jsx
+++ b/src/common-components/tests/UnAuthOnlyRoute.test.jsx
@@ -2,7 +2,6 @@
 /* eslint-disable react/function-component-definition */
 import React from 'react';
 
-import { getConfig } from '@edx/frontend-platform';
 import { fetchAuthenticatedUser, getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
@@ -69,45 +68,5 @@ describe('UnAuthOnlyRoute', () => {
     });
 
     expect(fetchAuthenticatedUser).toBeCalledWith({ forceRefresh: false });
-  });
-
-  it('should not route to register page for authenticated users with non-embedded/normal experience', async () => {
-    const user = {
-      username: 'gonzo',
-      other: 'data',
-    };
-
-    getAuthenticatedUser.mockReturnValue(user);
-    fetchAuthenticatedUser.mockReturnValueOnce(Promise.resolve(user));
-
-    let registerPage = null;
-
-    await act(async () => {
-      registerPage = await mount(routerWrapper());
-    });
-
-    expect(registerPage.find('span').exists()).toBeFalsy();
-  });
-
-  it('should route to register page for authenticated users with embedded experience', async () => {
-    const user = {
-      username: 'gonzo',
-      other: 'data',
-    };
-
-    delete window.location;
-    window.location = { href: getConfig().BASE_URL.concat(REGISTER_PAGE), search: '?variant=embedded&host=http://localhost/host-websit' };
-
-    getAuthenticatedUser.mockReturnValue(user);
-    fetchAuthenticatedUser.mockReturnValueOnce(Promise.resolve(user));
-
-    let registerPage = null;
-
-    await act(async () => {
-      registerPage = await mount(routerWrapper());
-    });
-
-    expect(registerPage.find('span').exists()).toBeTruthy();
-    expect(registerPage.find('span').text()).toBe('Register Page');
   });
 });

--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1,6 +1,7 @@
 // URL Paths
 export const LOGIN_PAGE = '/login';
 export const REGISTER_PAGE = '/register';
+export const REGISTER_EMBEDDED_PAGE = '/register-embedded';
 export const RESET_PAGE = '/reset';
 export const AUTHN_PROGRESSIVE_PROFILING = '/welcome';
 export const DEFAULT_REDIRECT_URL = '/dashboard';

--- a/src/data/utils/dataUtils.js
+++ b/src/data/utils/dataUtils.js
@@ -1,7 +1,7 @@
 // Utility functions
 import * as QueryString from 'query-string';
 
-import { AUTH_PARAMS, EMBEDDED } from '../constants';
+import { AUTH_PARAMS } from '../constants';
 
 export const getTpaProvider = (tpaHintProvider, primaryProviders, secondaryProviders) => {
   let tpaProvider = null;
@@ -77,7 +77,7 @@ export const windowScrollTo = (options) => {
   return window.scrollTo(options.top, options.left);
 };
 
-export const isRegistrationEmbedded = () => {
+export const isHostAvailableInQueryParams = () => {
   const queryParams = getAllPossibleQueryParams();
-  return queryParams?.variant === EMBEDDED && 'host' in queryParams;
+  return 'host' in queryParams;
 };

--- a/src/data/utils/index.js
+++ b/src/data/utils/index.js
@@ -3,7 +3,7 @@ export {
   getTpaHint,
   getAllPossibleQueryParams,
   getActivationStatus,
-  isRegistrationEmbedded,
+  isHostAvailableInQueryParams,
   updatePathWithQueryParams,
   windowScrollTo,
 } from './dataUtils';

--- a/src/logistration/Logistration.jsx
+++ b/src/logistration/Logistration.jsx
@@ -22,7 +22,7 @@ import {
 import messages from '../common-components/messages';
 import { LOGIN_PAGE, REGISTER_PAGE } from '../data/constants';
 import {
-  getTpaHint, getTpaProvider, isRegistrationEmbedded, updatePathWithQueryParams,
+  getTpaHint, getTpaProvider, updatePathWithQueryParams,
 } from '../data/utils';
 import { LoginPage } from '../login';
 import { RegistrationPage } from '../register';
@@ -38,7 +38,6 @@ const Logistration = (props) => {
   const [institutionLogin, setInstitutionLogin] = useState(false);
   const [key, setKey] = useState('');
   const disablePublicAccountCreation = getConfig().ALLOW_PUBLIC_ACCOUNT_CREATION === false;
-  const registrationEmbedded = isRegistrationEmbedded() && selectedPage === REGISTER_PAGE;
 
   useEffect(() => {
     const authService = getAuthService();
@@ -82,64 +81,58 @@ const Logistration = (props) => {
     const { provider } = getTpaProvider(tpaHint, providers, secondaryProviders);
     return !!provider;
   };
-  const renderLogistrationTabs = () => (
-    <div>
-      {disablePublicAccountCreation
-        ? (
-          <>
-            <Redirect to={updatePathWithQueryParams(LOGIN_PAGE)} />
-            {institutionLogin && (
-              <Tabs defaultActiveKey="" id="controlled-tab" onSelect={handleInstitutionLogin}>
-                <Tab title={tabTitle} eventKey={LOGIN_PAGE} />
-              </Tabs>
-            )}
-            <div id="main-content" className="main-content">
-              {!institutionLogin && (
-                <h3 className="mb-4.5">{formatMessage(messages['logistration.sign.in'])}</h3>
-              )}
-              <LoginPage institutionLogin={institutionLogin} handleInstitutionLogin={handleInstitutionLogin} />
-            </div>
-          </>
-        )
-        : (
-          <div>
-            {institutionLogin
-              ? (
-                <Tabs defaultActiveKey="" id="controlled-tab" onSelect={handleInstitutionLogin}>
-                  <Tab title={tabTitle} eventKey={selectedPage === LOGIN_PAGE ? LOGIN_PAGE : REGISTER_PAGE} />
-                </Tabs>
-              )
-              : (!registrationEmbedded && !isValidTpaHint() && (
-                <Tabs defaultActiveKey={selectedPage} id="controlled-tab" onSelect={handleOnSelect}>
-                  <Tab title={formatMessage(messages['logistration.register'])} eventKey={REGISTER_PAGE} />
-                  <Tab title={formatMessage(messages['logistration.sign.in'])} eventKey={LOGIN_PAGE} />
-                </Tabs>
-              ))}
-            { key && (
-              <Redirect to={updatePathWithQueryParams(key)} />
-            )}
-            <div id="main-content" className="main-content">
-              {selectedPage === LOGIN_PAGE
-                ? <LoginPage institutionLogin={institutionLogin} handleInstitutionLogin={handleInstitutionLogin} />
-                : (
-                  <RegistrationPage
-                    institutionLogin={institutionLogin}
-                    handleInstitutionLogin={handleInstitutionLogin}
-                  />
-                )}
-            </div>
-          </div>
-        )}
-    </div>
-  );
+
   return (
-    registrationEmbedded ? (
-      renderLogistrationTabs()
-    ) : (
-      <BaseComponent>
-        {renderLogistrationTabs()}
-      </BaseComponent>
-    )
+    <BaseComponent>
+      <div>
+        {disablePublicAccountCreation
+          ? (
+            <>
+              <Redirect to={updatePathWithQueryParams(LOGIN_PAGE)} />
+              {institutionLogin && (
+                <Tabs defaultActiveKey="" id="controlled-tab" onSelect={handleInstitutionLogin}>
+                  <Tab title={tabTitle} eventKey={LOGIN_PAGE} />
+                </Tabs>
+              )}
+              <div id="main-content" className="main-content">
+                {!institutionLogin && (
+                  <h3 className="mb-4.5">{formatMessage(messages['logistration.sign.in'])}</h3>
+                )}
+                <LoginPage institutionLogin={institutionLogin} handleInstitutionLogin={handleInstitutionLogin} />
+              </div>
+            </>
+          )
+          : (
+            <div>
+              {institutionLogin
+                ? (
+                  <Tabs defaultActiveKey="" id="controlled-tab" onSelect={handleInstitutionLogin}>
+                    <Tab title={tabTitle} eventKey={selectedPage === LOGIN_PAGE ? LOGIN_PAGE : REGISTER_PAGE} />
+                  </Tabs>
+                )
+                : (!isValidTpaHint() && (
+                  <Tabs defaultActiveKey={selectedPage} id="controlled-tab" onSelect={handleOnSelect}>
+                    <Tab title={formatMessage(messages['logistration.register'])} eventKey={REGISTER_PAGE} />
+                    <Tab title={formatMessage(messages['logistration.sign.in'])} eventKey={LOGIN_PAGE} />
+                  </Tabs>
+                ))}
+              { key && (
+                <Redirect to={updatePathWithQueryParams(key)} />
+              )}
+              <div id="main-content" className="main-content">
+                {selectedPage === LOGIN_PAGE
+                  ? <LoginPage institutionLogin={institutionLogin} handleInstitutionLogin={handleInstitutionLogin} />
+                  : (
+                    <RegistrationPage
+                      institutionLogin={institutionLogin}
+                      handleInstitutionLogin={handleInstitutionLogin}
+                    />
+                  )}
+              </div>
+            </div>
+          )}
+      </div>
+    </BaseComponent>
   );
 };
 

--- a/src/logistration/Logistration.test.jsx
+++ b/src/logistration/Logistration.test.jsx
@@ -12,7 +12,7 @@ import Logistration from './Logistration';
 import { clearThirdPartyAuthContextErrorMessage } from '../common-components/data/actions';
 import { RenderInstitutionButton } from '../common-components/InstitutionLogistration';
 import {
-  COMPLETE_STATE, LOGIN_PAGE, REGISTER_PAGE,
+  COMPLETE_STATE, LOGIN_PAGE,
 } from '../data/constants';
 import { backupRegistrationForm } from '../register/data/actions';
 
@@ -61,26 +61,6 @@ describe('Logistration', () => {
     });
   });
 
-  it('should not render logistration tabs for embedded registration form', () => {
-    delete window.location;
-    window.location = { href: getConfig().BASE_URL.concat(REGISTER_PAGE), search: '?variant=embedded&host=http://localhost/host-website' };
-
-    store = mockStore({
-      register: {
-        registrationResult: { success: false, redirectUrl: '' },
-        registrationError: {},
-      },
-      commonComponents: {
-        thirdPartyAuthContext: {
-          providers: [],
-          secondaryProviders: [],
-        },
-      },
-    });
-    const logistration = mount(reduxWrapper(<IntlLogistration />));
-
-    expect(logistration.find('#controlled-tab').exists()).toBeFalsy();
-  });
   it('should render registration page', () => {
     mergeConfig({
       ALLOW_PUBLIC_ACCOUNT_CREATION: true,

--- a/src/progressive-profiling/ProgressiveProfiling.jsx
+++ b/src/progressive-profiling/ProgressiveProfiling.jsx
@@ -36,7 +36,7 @@ import {
   FAILURE_STATE,
   PENDING_STATE,
 } from '../data/constants';
-import { getAllPossibleQueryParams, isRegistrationEmbedded } from '../data/utils';
+import { getAllPossibleQueryParams, isHostAvailableInQueryParams } from '../data/utils';
 import { FormFieldRenderer } from '../field-renderer';
 import {
   activateRecommendationsExperiment, RECOMMENDATIONS_EXP_VARIATION, trackRecommendationViewedOptimizely,
@@ -53,7 +53,7 @@ const ProgressiveProfiling = (props) => {
     welcomePageContext,
     welcomePageContextApiStatus,
   } = props;
-  const registrationEmbedded = isRegistrationEmbedded();
+  const registrationEmbedded = isHostAvailableInQueryParams();
 
   const authenticatedUser = getAuthenticatedUser();
   const DASHBOARD_URL = getConfig().LMS_BASE_URL.concat(DEFAULT_REDIRECT_URL);

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -51,7 +51,7 @@ import {
   INVALID_NAME_REGEX, LETTER_REGEX, NUMBER_REGEX, PENDING_STATE, REGISTER_PAGE, VALID_EMAIL_REGEX,
 } from '../data/constants';
 import {
-  getAllPossibleQueryParams, getTpaHint, getTpaProvider, isRegistrationEmbedded, setCookie,
+  getAllPossibleQueryParams, getTpaHint, getTpaProvider, isHostAvailableInQueryParams, setCookie,
 } from '../data/utils';
 
 const emailRegex = new RegExp(VALID_EMAIL_REGEX, 'i');
@@ -87,7 +87,7 @@ const RegistrationPage = (props) => {
   const { formatMessage } = useIntl();
   const countryList = useMemo(() => getCountryList(getLocale()), []);
   const queryParams = useMemo(() => getAllPossibleQueryParams(), []);
-  const registrationEmbedded = isRegistrationEmbedded();
+  const registrationEmbedded = isHostAvailableInQueryParams();
   const { host } = queryParams;
   const tpaHint = useMemo(() => getTpaHint(), []);
   const flags = {
@@ -538,7 +538,7 @@ const RegistrationPage = (props) => {
           <div
             className={classNames(
               'mw-xs mt-3',
-              { 'w-100 m-auto': registrationEmbedded },
+              { 'w-100 m-auto pt-4': registrationEmbedded },
             )}
           >
             <ThirdPartyAuthAlert
@@ -694,7 +694,7 @@ RegistrationPage.propTypes = {
     password: PropTypes.string,
   }),
   fieldDescriptions: PropTypes.shape({}),
-  institutionLogin: PropTypes.bool.isRequired,
+  institutionLogin: PropTypes.bool,
   optionalFields: PropTypes.shape({}),
   registrationError: PropTypes.shape({}),
   registrationErrorCode: PropTypes.string,
@@ -733,7 +733,7 @@ RegistrationPage.propTypes = {
   backupFormState: PropTypes.func.isRequired,
   clearBackendError: PropTypes.func.isRequired,
   getRegistrationDataFromBackend: PropTypes.func.isRequired,
-  handleInstitutionLogin: PropTypes.func.isRequired,
+  handleInstitutionLogin: PropTypes.func,
   registerNewUser: PropTypes.func.isRequired,
   resetUsernameSuggestions: PropTypes.func.isRequired,
   setUserPipelineDetailsLoaded: PropTypes.func.isRequired,
@@ -758,6 +758,8 @@ RegistrationPage.defaultProps = {
   backendCountryCode: '',
   backendValidations: null,
   fieldDescriptions: {},
+  handleInstitutionLogin: null,
+  institutionLogin: false,
   optionalFields: {},
   registrationError: {},
   registrationErrorCode: '',


### PR DESCRIPTION
### Description

This PR updates the embedded registration rendering from the `?variant=embedded` query param to the `/register-embedded` path.

#### JIRA

[XXX-XXXX](https://2u-internal.atlassian.net/browse/XXX-XXXX)

#### How Has This Been Tested?

Please describe in detail how you tested your changes.

#### Screenshots/sandbox (optional):

Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if its not applicable.**

|Before|After|
|-------|-----|
|      |      |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
