### PR TITLE
feat: keep username suggestion for origin

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -412,10 +412,19 @@ const RegistrationPage = (props) => {
   };
 
   const handleOnBlur = (event) => {
+    const { name, value } = event.target;
     if (registrationEmbedded) {
+      if (name === 'name') {
+        validateInput(
+          name,
+          value,
+          { name: formFields.name, username: formFields.username, form_field_key: name },
+          !validationApiRateLimited,
+          false,
+        );
+      }
       return;
     }
-    const { name, value } = event.target;
     const payload = {
       name: formFields.name,
       email: formFields.email,

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -252,7 +252,7 @@ describe('RegistrationPage', () => {
 
     it('should not run validations on blur event when embedded variant is rendered', () => {
       delete window.location;
-      window.location = { href: getConfig().BASE_URL.concat(REGISTER_PAGE), search: '?variant=embedded&host=http://localhost/host-website' };
+      window.location = { href: getConfig().BASE_URL.concat(REGISTER_PAGE), search: '?host=http://localhost/host-website' };
       const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />));
 
       registrationPage.find('input#username').simulate('blur', { target: { value: '', name: 'username' } });
@@ -883,7 +883,7 @@ describe('RegistrationPage', () => {
       window.parent.postMessage = jest.fn();
 
       delete window.location;
-      window.location = { href: getConfig().BASE_URL.concat(AUTHN_PROGRESSIVE_PROFILING), search: '?variant=embedded&host=http://localhost/host-website' };
+      window.location = { href: getConfig().BASE_URL.concat(AUTHN_PROGRESSIVE_PROFILING), search: '?host=http://localhost/host-website' };
 
       store = mockStore({
         ...initialState,


### PR DESCRIPTION
### Description

For the embedded registration form experience even though we do not want to show error on blur we still want to keep the username suggestions that are fetched on the "name" field on blur event. 

#### JIRA

[VAN-1498](https://2u-internal.atlassian.net/browse/VAN-1498)

**Don't show error on blur for empty "name" field** 

https://github.com/openedx/frontend-app-authn/assets/40633976/56a30c64-3712-4fa1-af1c-fe4dfa7826c8

**Don't show error on blur for invalid "name" field**

https://github.com/openedx/frontend-app-authn/assets/40633976/88f57239-9aa5-4994-abb5-18ebf69ca7a8

**Show username suggestion**

https://github.com/openedx/frontend-app-authn/assets/40633976/2f86cda3-91e5-4e9c-bb7d-8ee0dfeec61a


