### PR TITLE
Revert "feat: fire identify call and register event"

### DIFF
--- a/src/progressive-profiling/ProgressiveProfiling.jsx
+++ b/src/progressive-profiling/ProgressiveProfiling.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 
 import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
-import { sendPageEvent, sendTrackEvent } from '@edx/frontend-platform/analytics';
+import { identifyAuthenticatedUser, sendPageEvent, sendTrackEvent } from '@edx/frontend-platform/analytics';
 import {
   AxiosJwtAuthService,
   configure as configureAuth,
@@ -105,10 +105,11 @@ const ProgressiveProfiling = (props) => {
   }, [registrationEmbedded, welcomePageContext]);
 
   useEffect(() => {
-    if (canViewWelcomePage) {
+    if (canViewWelcomePage && authenticatedUser?.userId) {
+      identifyAuthenticatedUser(authenticatedUser.userId);
       sendPageEvent('login_and_registration', 'welcome');
     }
-  }, [canViewWelcomePage]);
+  }, [authenticatedUser, canViewWelcomePage]);
 
   useEffect(() => {
     if (registrationResult.redirectUrl && authenticatedUser?.userId) {

--- a/src/progressive-profiling/tests/ProgressiveProfiling.test.jsx
+++ b/src/progressive-profiling/tests/ProgressiveProfiling.test.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import { getConfig, mergeConfig } from '@edx/frontend-platform';
-import { sendTrackEvent } from '@edx/frontend-platform/analytics';
+import { identifyAuthenticatedUser, sendTrackEvent } from '@edx/frontend-platform/analytics';
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { configure, injectIntl, IntlProvider } from '@edx/frontend-platform/i18n';
 import { mount } from 'enzyme';
@@ -27,6 +27,7 @@ const mockStore = configureStore();
 jest.mock('@edx/frontend-platform/analytics', () => ({
   sendPageEvent: jest.fn(),
   sendTrackEvent: jest.fn(),
+  identifyAuthenticatedUser: jest.fn(),
 }));
 jest.mock('@edx/frontend-platform/auth', () => ({
   configure: jest.fn(),
@@ -131,6 +132,13 @@ describe('ProgressiveProfilingTests', () => {
     const progressiveProfilingPage = await getProgressiveProfilingPage();
 
     expect(progressiveProfilingPage.find('a.pgn__hyperlink').text()).toEqual('Learn more about how we use this information.');
+  });
+
+  it('should make identify call to segment on progressive profiling page', async () => {
+    getAuthenticatedUser.mockReturnValue({ userId: 3, username: 'abc123' });
+    await getProgressiveProfilingPage();
+    expect(identifyAuthenticatedUser).toHaveBeenCalledWith(3);
+    expect(identifyAuthenticatedUser).toHaveBeenCalled();
   });
 
   it('should submit user profile details on form submission', async () => {

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -312,7 +312,7 @@ const RegistrationPage = (props) => {
         break;
       default:
         if (flags.showConfigurableRegistrationFields) {
-          if (!value && fieldDescriptions[fieldName].error_message) {
+          if (!value && fieldDescriptions[fieldName]?.error_message) {
             fieldError = fieldDescriptions[fieldName].error_message;
           } else if (fieldName === 'confirm_email' && formFields.email && value !== formFields.email) {
             fieldError = formatMessage(messages['email.do.not.match']);
@@ -468,7 +468,7 @@ const RegistrationPage = (props) => {
     const { fieldError: focusedFieldError, countryFieldCode } = focusedField ? (
       validateInput(
         focusedField,
-        (focusedField in fieldDescriptions || focusedField === 'country') ? (
+        (focusedField in fieldDescriptions || ['country', 'marketingEmailsOptIn'].includes(focusedField)) ? (
           configurableFormFields[focusedField]
         ) : formFields[focusedField],
         payload,

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -4,7 +4,7 @@ import React, {
 import { connect } from 'react-redux';
 
 import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
-import { identifyAuthenticatedUser, sendPageEvent, sendTrackEvent } from '@edx/frontend-platform/analytics';
+import { sendPageEvent } from '@edx/frontend-platform/analytics';
 import {
   getCountryList, getLocale, useIntl,
 } from '@edx/frontend-platform/i18n';
@@ -235,30 +235,8 @@ const RegistrationPage = (props) => {
       window.dataLayer.push({
         event: 'ImpactRegistrationEvent',
       });
-
-      // preparing identify call traits
-      const traits = { ...formFields };
-      delete traits.password;
-      traits.country = configurableFormFields?.country?.countryCode;
-      traits.is_marketable = configurableFormFields.marketingEmailsOptIn;
-      traits.email_subscribe = configurableFormFields.marketingEmailsOptIn ? 'subscribed' : 'unsubscribed';
-      identifyAuthenticatedUser(registrationResult.userId, traits);
-
-      // preparing register event properties
-      const properties = {
-        category: 'conversion',
-        email: formFields.email,
-        label: queryParams?.course_id || null,
-        provider: currentProvider?.name || null,
-        host: queryParams?.host || '',
-        marketing_emails_opt_in: configurableFormFields.marketingEmailsOptIn,
-      };
-      sendTrackEvent(
-        'edx.bi.user.account.registered.client',
-        properties,
-      );
     }
-  }, [registrationResult]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [registrationResult]);
 
   const validateInput = (fieldName, value, payload, shouldValidateFromBackend, setError = true) => {
     let fieldError = '';
@@ -334,7 +312,7 @@ const RegistrationPage = (props) => {
         break;
       default:
         if (flags.showConfigurableRegistrationFields) {
-          if (!value && fieldDescriptions[fieldName]?.error_message) {
+          if (!value && fieldDescriptions[fieldName].error_message) {
             fieldError = fieldDescriptions[fieldName].error_message;
           } else if (fieldName === 'confirm_email' && formFields.email && value !== formFields.email) {
             fieldError = formatMessage(messages['email.do.not.match']);
@@ -490,7 +468,7 @@ const RegistrationPage = (props) => {
     const { fieldError: focusedFieldError, countryFieldCode } = focusedField ? (
       validateInput(
         focusedField,
-        (focusedField in fieldDescriptions || ['country', 'marketingEmailsOptIn'].includes(focusedField)) ? (
+        (focusedField in fieldDescriptions || focusedField === 'country') ? (
           configurableFormFields[focusedField]
         ) : formFields[focusedField],
         payload,
@@ -732,7 +710,6 @@ RegistrationPage.propTypes = {
   registrationResult: PropTypes.shape({
     redirectUrl: PropTypes.string,
     success: PropTypes.bool,
-    userId: PropTypes.number,
   }),
   shouldBackupState: PropTypes.bool,
   submitState: PropTypes.string,

--- a/src/register/data/actions.js
+++ b/src/register/data/actions.js
@@ -47,9 +47,9 @@ export const registerNewUserBegin = () => ({
   type: REGISTER_NEW_USER.BEGIN,
 });
 
-export const registerNewUserSuccess = (redirectUrl, success, userId) => ({
+export const registerNewUserSuccess = (redirectUrl, success) => ({
   type: REGISTER_NEW_USER.SUCCESS,
-  payload: { redirectUrl, success, userId },
+  payload: { redirectUrl, success },
 
 });
 

--- a/src/register/data/sagas.js
+++ b/src/register/data/sagas.js
@@ -19,12 +19,11 @@ export function* handleNewUserRegistration(action) {
   try {
     yield put(registerNewUserBegin());
 
-    const { redirectUrl, success, userId } = yield call(registerRequest, action.payload.registrationInfo);
+    const { redirectUrl, success } = yield call(registerRequest, action.payload.registrationInfo);
 
     yield put(registerNewUserSuccess(
       redirectUrl,
       success,
-      userId,
     ));
   } catch (e) {
     const statusCodes = [400, 403, 409];

--- a/src/register/data/service.js
+++ b/src/register/data/service.js
@@ -21,7 +21,6 @@ export async function registerRequest(registrationInformation) {
   return {
     redirectUrl: data.redirect_url || `${getConfig().LMS_BASE_URL}/dashboard`,
     success: data.success || false,
-    userId: data?.user_id,
   };
 }
 

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -31,7 +31,6 @@ import RegistrationPage from '../RegistrationPage';
 jest.mock('@edx/frontend-platform/analytics', () => ({
   sendPageEvent: jest.fn(),
   sendTrackEvent: jest.fn(),
-  identifyAuthenticatedUser: jest.fn(),
 }));
 jest.mock('@edx/frontend-platform/i18n', () => ({
   ...jest.requireActual('@edx/frontend-platform/i18n'),


### PR DESCRIPTION
Reverts openedx/frontend-app-authn#951

We added this as a debugging event to check if backend event was firing correctly. We have established that it is and we no longer need this event.