### PR TITLE
feat: hide privacy banner for embedded form

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,18 @@
               crossorigin="anonymous"
               referrerpolicy="no-referrer">
       </script>
+      <script>
+        setTimeout(function() {
+          const currentPath = window.location.pathname;
+          if (currentPath === '/register-embedded') {
+            const privacyBannerElement = document.querySelector('.cc-grower');
+            if (privacyBannerElement) {
+              // Hide the privacy banner element for embedded authn experience
+              privacyBannerElement.classList.add('d-none');
+            }
+          }
+        }, 1500);
+      </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
### Description

For the embedded experience the privacy banner is appearing twice. We want to hide the one on the form:
![Screenshot 2023-06-22 at 2 34 43 PM](https://github.com/openedx/frontend-app-authn/assets/40633976/30a6f92d-6716-45e3-af5c-f025f7c50f41)

I have added a script that runs after 1.5 seconds and hides the banner with class `cc-grower`.

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
