### PR TITLE
Revert "feat: hide privacy banner for embedded form"

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,18 +9,6 @@
               crossorigin="anonymous"
               referrerpolicy="no-referrer">
       </script>
-      <script>
-        setTimeout(function() {
-          const currentPath = window.location.pathname;
-          if (currentPath === '/register-embedded') {
-            const privacyBannerElement = document.querySelector('.cc-grower');
-            if (privacyBannerElement) {
-              // Hide the privacy banner element for embedded authn experience
-              privacyBannerElement.classList.add('d-none');
-            }
-          }
-        }, 1500);
-      </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Reverts openedx/frontend-app-authn#954

We no longer need this script because the privacy banner has been set not to show on the `/register-embedded` url using GTM.