### PR TITLE
Add image layout for base container

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -29,6 +29,11 @@ TOS_AND_HONOR_CODE='http://localhost:18000/honor'
 TOS_LINK='http://localhost:18000/tos'
 PRIVACY_POLICY='http://localhost:18000/privacy'
 AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK='http://localhost:1999/welcome'
+# ***** Base Container Images *****
+BANNER_IMAGE_LARGE=''
+BANNER_IMAGE_MEDIUM=''
+BANNER_IMAGE_SMALL=''
+BANNER_IMAGE_EXTRA_SMALL=''
 # ***** Miscellaneous *****
 APP_ID=''
 MFE_CONFIG_API_URL=''

--- a/src/base-container/components/default-layout/index.jsx
+++ b/src/base-container/components/default-layout/index.jsx
@@ -1,0 +1,3 @@
+export { default as DefaultLargeLayout } from './LargeLayout';
+export { default as DefaultMediumLayout } from './MediumLayout';
+export { default as DefaultSmallLayout } from './SmallLayout';

--- a/src/base-container/components/image-layout/ExtraSmallLayout.jsx
+++ b/src/base-container/components/image-layout/ExtraSmallLayout.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { getConfig } from '@edx/frontend-platform';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Hyperlink, Image } from '@edx/paragon';
+
+import messages from './messages';
+
+const ExtraSmallLayout = () => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <span
+      className="w-100 bg-primary-500 banner__image extra-small-layout"
+      style={{ backgroundImage: `url(${getConfig().BANNER_IMAGE_EXTRA_SMALL})` }}
+    >
+      <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
+        <Image className="company-logo" alt={getConfig().SITE_NAME} src={getConfig().LOGO_WHITE_URL} />
+      </Hyperlink>
+      <div className="ml-4.5 mr-1 pb-3.5 pt-3.5">
+        <h1 className="banner__heading">
+          <span className="text-light-500">
+            {formatMessage(messages['your.career.turning.point'])}{' '}
+          </span>
+          <span className="text-warning-300">
+            {formatMessage(messages['is.here'])}
+          </span>
+        </h1>
+      </div>
+    </span>
+  );
+};
+
+export default ExtraSmallLayout;

--- a/src/base-container/components/image-layout/LargeLayout.jsx
+++ b/src/base-container/components/image-layout/LargeLayout.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { getConfig } from '@edx/frontend-platform';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Hyperlink, Image } from '@edx/paragon';
+
+import './index.scss';
+import messages from './messages';
+
+const LargeLayout = () => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <div
+      className="w-50 vh-100 bg-primary-500 banner__image large-layout"
+      style={{ backgroundImage: `url(${getConfig().BANNER_IMAGE_LARGE})` }}
+    >
+      <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
+        <Image className="company-logo position-absolute" alt={getConfig().SITE_NAME} src={getConfig().LOGO_WHITE_URL} />
+      </Hyperlink>
+      <div className="min-vh-100 p-5 d-flex align-items-end">
+        <h1 className="display-2 mw-sm mb-3 d-flex flex-column flex-shrink-0 justify-content-center">
+          <span className="text-light-500">
+            {formatMessage(messages['your.career.turning.point'])}
+          </span>
+          <span className="text-warning-300">
+            {formatMessage(messages['is.here'])}
+          </span>
+        </h1>
+      </div>
+    </div>
+  );
+};
+
+export default LargeLayout;

--- a/src/base-container/components/image-layout/MediumLayout.jsx
+++ b/src/base-container/components/image-layout/MediumLayout.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { getConfig } from '@edx/frontend-platform';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Hyperlink, Image } from '@edx/paragon';
+
+import './index.scss';
+import messages from './messages';
+
+const MediumLayout = () => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <div
+      className="w-100 mb-3 bg-primary-500 banner__image medium-layout"
+      style={{ backgroundImage: `url(${getConfig().BANNER_IMAGE_MEDIUM})` }}
+    >
+      <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
+        <Image className="company-logo" alt={getConfig().SITE_NAME} src={getConfig().LOGO_WHITE_URL} />
+      </Hyperlink>
+      <div className="ml-5 pb-4 pt-4">
+        <h1 className="display-2 banner__heading">
+          <span className="text-light-500">
+            {formatMessage(messages['your.career.turning.point'])}{' '}
+          </span>
+          <span className="text-warning-300 d-inline-block">
+            {formatMessage(messages['is.here'])}
+          </span>
+        </h1>
+      </div>
+    </div>
+  );
+};
+
+export default MediumLayout;

--- a/src/base-container/components/image-layout/SmallLayout.jsx
+++ b/src/base-container/components/image-layout/SmallLayout.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { getConfig } from '@edx/frontend-platform';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Hyperlink, Image } from '@edx/paragon';
+
+import messages from './messages';
+
+const SmallLayout = () => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <span
+      className="w-100 bg-primary-500 banner__image small-layout"
+      style={{ backgroundImage: `url(${getConfig().BANNER_IMAGE_SMALL})` }}
+    >
+      <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
+        <Image className="company-logo" alt={getConfig().SITE_NAME} src={getConfig().LOGO_WHITE_URL} />
+      </Hyperlink>
+      <div className="ml-5 mr-1 pb-3.5 pt-3.5">
+        <h1 className="display-2">
+          <span className="text-light-500">
+            {formatMessage(messages['your.career.turning.point'])}{' '}
+          </span>
+          <span className="text-warning-300">
+            {formatMessage(messages['is.here'])}
+          </span>
+        </h1>
+      </div>
+    </span>
+  );
+};
+
+export default SmallLayout;

--- a/src/base-container/components/image-layout/index.jsx
+++ b/src/base-container/components/image-layout/index.jsx
@@ -1,0 +1,4 @@
+export { default as ImageLargeLayout } from './LargeLayout';
+export { default as ImageMediumLayout } from './MediumLayout';
+export { default as ImageSmallLayout } from './SmallLayout';
+export { default as ImageExtraSmallLayout } from './ExtraSmallLayout';

--- a/src/base-container/components/image-layout/index.scss
+++ b/src/base-container/components/image-layout/index.scss
@@ -1,0 +1,37 @@
+.company-logo {
+  width: 71px;
+  margin-top: 2rem;
+  margin-left: 1.5rem;
+}
+
+@media (max-width: 576px) {
+  .company-logo {
+    width: 44.67px;
+    margin-top: 1.25rem;
+    margin-left: 1.5rem;
+  }
+}
+
+.banner__image {
+  background-size: cover;
+  background-repeat: no-repeat;
+  border:none;
+}
+
+@media (min-width: 464px) and (max-width: 575.98px) {
+  .banner__heading {
+    font-size: 60px;
+    font-weight: 700;
+    line-height: 60px;
+    letter-spacing: -1.2px;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 800px) {
+  .banner__heading {
+    font-size: 60px !important;
+    font-weight: 700 !important;
+    line-height: 60px !important;
+    letter-spacing: -2px !important;
+  }
+}

--- a/src/base-container/components/image-layout/messages.js
+++ b/src/base-container/components/image-layout/messages.js
@@ -1,0 +1,16 @@
+import { defineMessages } from '@edx/frontend-platform/i18n';
+
+const messages = defineMessages({
+  'your.career.turning.point': {
+    id: 'your.career.turning.point',
+    defaultMessage: 'Your career turning point',
+    description: 'Part of the heading "Your career turning point is here." shown on Authn MFE',
+  },
+  'is.here': {
+    id: 'is.here',
+    defaultMessage: 'is here.',
+    description: 'Part of the heading "Your career turning point is here." shown on Authn MFE',
+  },
+});
+
+export default messages;

--- a/src/base-container/components/welcome-page-layout/LargeLayout.jsx
+++ b/src/base-container/components/welcome-page-layout/LargeLayout.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 
 import messages from './messages';
 
-const AuthLargeLayout = ({ username }) => {
+const LargeLayout = ({ username }) => {
   const { formatMessage } = useIntl();
 
   return (
@@ -42,8 +42,8 @@ const AuthLargeLayout = ({ username }) => {
   );
 };
 
-AuthLargeLayout.propTypes = {
+LargeLayout.propTypes = {
   username: PropTypes.string.isRequired,
 };
 
-export default AuthLargeLayout;
+export default LargeLayout;

--- a/src/base-container/components/welcome-page-layout/MediumLayout.jsx
+++ b/src/base-container/components/welcome-page-layout/MediumLayout.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 
 import messages from './messages';
 
-const AuthMediumLayout = ({ username }) => {
+const MediumLayout = ({ username }) => {
   const { formatMessage } = useIntl();
 
   return (
@@ -45,8 +45,8 @@ const AuthMediumLayout = ({ username }) => {
   );
 };
 
-AuthMediumLayout.propTypes = {
+MediumLayout.propTypes = {
   username: PropTypes.string.isRequired,
 };
 
-export default AuthMediumLayout;
+export default MediumLayout;

--- a/src/base-container/components/welcome-page-layout/SmallLayout.jsx
+++ b/src/base-container/components/welcome-page-layout/SmallLayout.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 
 import messages from './messages';
 
-const AuthSmallLayout = ({ username }) => {
+const SmallLayout = ({ username }) => {
   const { formatMessage } = useIntl();
 
   return (
@@ -34,8 +34,8 @@ const AuthSmallLayout = ({ username }) => {
   );
 };
 
-AuthSmallLayout.propTypes = {
+SmallLayout.propTypes = {
   username: PropTypes.string.isRequired,
 };
 
-export default AuthSmallLayout;
+export default SmallLayout;

--- a/src/base-container/components/welcome-page-layout/index.jsx
+++ b/src/base-container/components/welcome-page-layout/index.jsx
@@ -1,0 +1,3 @@
+export { default as AuthLargeLayout } from './LargeLayout';
+export { default as AuthMediumLayout } from './MediumLayout';
+export { default as AuthSmallLayout } from './SmallLayout';

--- a/src/base-container/data/constants.js
+++ b/src/base-container/data/constants.js
@@ -1,0 +1,3 @@
+const DEFAULT_LAYOUT = 'default-layout';
+
+export default DEFAULT_LAYOUT;

--- a/src/base-container/index.jsx
+++ b/src/base-container/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { breakpoints } from '@edx/paragon';
@@ -6,36 +6,59 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import MediaQuery from 'react-responsive';
 
-import LargeLayout from './components/default-layout/LargeLayout';
-import MediumLayout from './components/default-layout/MediumLayout';
-import SmallLayout from './components/default-layout/SmallLayout';
-import AuthLargeLayout from './components/welcome-page-layout/AuthLargeLayout';
-import AuthMediumLayout from './components/welcome-page-layout/AuthMediumLayout';
-import AuthSmallLayout from './components/welcome-page-layout/AuthSmallLayout';
+import { DefaultLargeLayout, DefaultMediumLayout, DefaultSmallLayout } from './components/default-layout';
+import {
+  ImageExtraSmallLayout, ImageLargeLayout, ImageMediumLayout, ImageSmallLayout,
+} from './components/image-layout';
+import { AuthLargeLayout, AuthMediumLayout, AuthSmallLayout } from './components/welcome-page-layout';
+import DEFAULT_LAYOUT from './data/constants';
 
 const BaseContainer = ({ children, showWelcomeBanner }) => {
   const authenticatedUser = showWelcomeBanner ? getAuthenticatedUser() : null;
   const username = authenticatedUser ? authenticatedUser.username : null;
+  // eslint-disable-next-line no-unused-vars
+  const [baseContainerVersion, setBaseContainerVersion] = useState(DEFAULT_LAYOUT);
+
+  if (baseContainerVersion === DEFAULT_LAYOUT) {
+    return (
+      <>
+        <div className="col-md-12 extra-large-screen-top-stripe" />
+        <div className="layout">
+          <MediaQuery maxWidth={breakpoints.small.maxWidth - 1}>
+            {authenticatedUser ? <AuthSmallLayout username={username} /> : <DefaultSmallLayout />}
+          </MediaQuery>
+          <MediaQuery minWidth={breakpoints.medium.minWidth} maxWidth={breakpoints.large.maxWidth - 1}>
+            {authenticatedUser ? <AuthMediumLayout username={username} /> : <DefaultMediumLayout />}
+          </MediaQuery>
+          <MediaQuery minWidth={breakpoints.extraLarge.minWidth}>
+            {authenticatedUser ? <AuthLargeLayout username={username} /> : <DefaultLargeLayout />}
+          </MediaQuery>
+          <div className={classNames('content', { 'align-items-center mt-0': authenticatedUser })}>
+            {children}
+          </div>
+        </div>
+      </>
+    );
+  }
 
   return (
-    <>
-      <div className="col-md-12 extra-large-screen-top-stripe" />
-      <div className="layout">
-        <MediaQuery maxWidth={breakpoints.small.maxWidth - 1}>
-          {authenticatedUser ? <AuthSmallLayout username={username} /> : <SmallLayout />}
-        </MediaQuery>
-        <MediaQuery minWidth={breakpoints.medium.minWidth} maxWidth={breakpoints.large.maxWidth - 1}>
-          {authenticatedUser ? <AuthMediumLayout username={username} /> : <MediumLayout />}
-        </MediaQuery>
-        <MediaQuery minWidth={breakpoints.extraLarge.minWidth} maxWidth={breakpoints.extraExtraLarge.maxWidth}>
-          {authenticatedUser ? <AuthLargeLayout username={username} /> : <LargeLayout />}
-        </MediaQuery>
-
-        <div className={classNames('content', { 'align-items-center mt-0': authenticatedUser })}>
-          {children}
-        </div>
+    <div className="layout">
+      <MediaQuery maxWidth={breakpoints.extraSmall.maxWidth - 1}>
+        {authenticatedUser ? <AuthSmallLayout username={username} /> : <ImageExtraSmallLayout />}
+      </MediaQuery>
+      <MediaQuery minWidth={breakpoints.small.minWidth} maxWidth={breakpoints.small.maxWidth - 1}>
+        {authenticatedUser ? <AuthSmallLayout username={username} /> : <ImageSmallLayout />}
+      </MediaQuery>
+      <MediaQuery minWidth={breakpoints.medium.minWidth} maxWidth={breakpoints.large.maxWidth - 1}>
+        {authenticatedUser ? <AuthMediumLayout username={username} /> : <ImageMediumLayout />}
+      </MediaQuery>
+      <MediaQuery minWidth={breakpoints.extraLarge.minWidth}>
+        {authenticatedUser ? <AuthLargeLayout username={username} /> : <ImageLargeLayout />}
+      </MediaQuery>
+      <div className={classNames('content', { 'align-items-center mt-0': authenticatedUser })}>
+        {children}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/base-container/index.jsx
+++ b/src/base-container/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { breakpoints } from '@edx/paragon';
@@ -16,8 +16,23 @@ import DEFAULT_LAYOUT from './data/constants';
 const BaseContainer = ({ children, showWelcomeBanner }) => {
   const authenticatedUser = showWelcomeBanner ? getAuthenticatedUser() : null;
   const username = authenticatedUser ? authenticatedUser.username : null;
-  // eslint-disable-next-line no-unused-vars
+
   const [baseContainerVersion, setBaseContainerVersion] = useState(DEFAULT_LAYOUT);
+
+  useEffect(() => {
+    const initRebrandExperiment = () => {
+      if (window.experiments?.rebrandExperiment) {
+        setBaseContainerVersion(window.experiments?.rebrandExperiment?.variation);
+      } else {
+        window.experiments = window.experiments || {};
+        window.experiments.rebrandExperiment = {};
+        window.experiments.rebrandExperiment.handleLoaded = () => {
+          setBaseContainerVersion(window.experiments?.rebrandExperiment?.variation);
+        };
+      }
+    };
+    initRebrandExperiment();
+  }, []);
 
   if (baseContainerVersion === DEFAULT_LAYOUT) {
     return (

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -19,11 +19,17 @@ const configuration = {
   SEARCH_CATALOG_URL: process.env.SEARCH_CATALOG_URL || null,
   TOS_AND_HONOR_CODE: process.env.TOS_AND_HONOR_CODE || null,
   TOS_LINK: process.env.TOS_LINK || null,
+  // Base container images
+  BANNER_IMAGE_LARGE: process.env.BANNER_IMAGE_LARGE || '',
+  BANNER_IMAGE_MEDIUM: process.env.BANNER_IMAGE_MEDIUM || '',
+  BANNER_IMAGE_SMALL: process.env.BANNER_IMAGE_SMALL || '',
+  BANNER_IMAGE_EXTRA_SMALL: process.env.BANNER_IMAGE_EXTRA_SMALL || '',
   // Miscellaneous
   GENERAL_RECOMMENDATIONS: process.env.GENERAL_RECOMMENDATIONS || '[]',
   INFO_EMAIL: process.env.INFO_EMAIL || '',
   ZENDESK_KEY: process.env.ZENDESK_KEY,
   ZENDESK_LOGO_URL: process.env.ZENDESK_LOGO_URL,
+  TEST_IMG: process.env.TEST_IMG,
 };
 
 export default configuration;

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -29,7 +29,6 @@ const configuration = {
   INFO_EMAIL: process.env.INFO_EMAIL || '',
   ZENDESK_KEY: process.env.ZENDESK_KEY,
   ZENDESK_LOGO_URL: process.env.ZENDESK_LOGO_URL,
-  TEST_IMG: process.env.TEST_IMG,
 };
 
 export default configuration;

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -227,6 +227,13 @@ const RegistrationPage = (props) => {
 
   useEffect(() => {
     if (registrationResult.success) {
+      // Optimizely registration conversion event
+      window.optimizely = window.optimizely || [];
+      window.optimizely.push({
+        type: 'event',
+        eventName: 'authn-registration-conversion',
+      });
+
       // This was added to fire social media conversion pixels through Google tag manager.
       setCookie(getConfig().REGISTER_CONVERSION_COOKIE_NAME, true);
 


### PR DESCRIPTION
### Description

As part of edx.org rebrand, this PR adds 
- another layout design for Base Container
- optimizely experiment setup for 

I have used [this guide](https://2u-internal.atlassian.net/wiki/spaces/GEM/pages/322699556/Implement+Optimizely+Experiments) for optimizely setup.

#### JIRA

[VAN-1506](https://2u-internal.atlassian.net/browse/VAN-1506)

#### How Has This Been Tested?

Locally

#### Screenshots/sandbox (optional):

|Size|With Image|Without Image|
|-------|-----|-------|
| Larger | <img width="768" alt="Screenshot 2023-06-28 at 2 40 40 PM" src="https://github.com/openedx/frontend-app-authn/assets/40633976/30a68d98-9d8a-4fc9-bf8a-2dfb53cda2f7">|<img width="1438" alt="Screenshot 2023-06-28 at 3 35 03 PM" src="https://github.com/openedx/frontend-app-authn/assets/40633976/06abcc42-e1e9-4d31-8d18-13bdfdbf3c09">|
| Medium | <img width="385" alt="Screenshot 2023-06-28 at 2 41 09 PM" src="https://github.com/openedx/frontend-app-authn/assets/40633976/3a879d64-ad46-498a-8ebd-eddd8c2c09bf"> | <img width="382" alt="Screenshot 2023-06-28 at 3 35 43 PM" src="https://github.com/openedx/frontend-app-authn/assets/40633976/740d3f4c-c575-447e-b455-60698aff3e66">|
| Small | <img width="286" alt="Screenshot 2023-06-28 at 2 41 24 PM" src="https://github.com/openedx/frontend-app-authn/assets/40633976/1dac0774-3052-4ef1-b2ce-3e0dbdcbdbd1"> |<img width="287" alt="Screenshot 2023-06-28 at 3 35 20 PM" src="https://github.com/openedx/frontend-app-authn/assets/40633976/bc8a495c-2331-4ae5-ac8f-51d272b9d20d">|


