### PR TITLE
fix: track event fire multiple times

### DIFF
--- a/src/progressive-profiling/ProgressiveProfiling.jsx
+++ b/src/progressive-profiling/ProgressiveProfiling.jsx
@@ -128,7 +128,7 @@ const ProgressiveProfiling = (props) => {
         }
       }
     }
-  }, [authenticatedUser, enablePopularAndTrendingRecommendations, registrationResult, queryParams?.next]);
+  }, [authenticatedUser, enablePopularAndTrendingRecommendations, registrationResult.redirectUrl, queryParams?.next]);
 
   if (
     !(location.state?.registrationResult || registrationEmbedded)


### PR DESCRIPTION
The recommendations group event was firing multiple times due to useEffect dependency because registrationResult is setting in the above two useEffects.

[VAN-1569](https://2u-internal.atlassian.net/browse/VAN-1569)