### PR TITLE
fix: autofilling fields is absent through registering process

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -130,7 +130,7 @@ const RegistrationPage = (props) => {
    */
   useEffect(() => {
     if (!userPipelineDataLoaded && thirdPartyAuthApiStatus === COMPLETE_STATE) {
-      const { autoSubmitRegForm, pipelineUserDetails, errorMessage } = thirdPartyAuthContext;
+      const { autoSubmitRegForm, errorMessage, pipeline_user_details: pipelineUserDetails } = thirdPartyAuthContext;
       if (errorMessage) {
         setErrorCode(prevState => ({ type: TPA_AUTHENTICATION_FAILURE, count: prevState.count + 1 }));
       } else if (autoSubmitRegForm) {
@@ -138,7 +138,13 @@ const RegistrationPage = (props) => {
         setAutoSubmitRegisterForm(true);
       }
       if (pipelineUserDetails && Object.keys(pipelineUserDetails).length !== 0) {
-        const { name = '', username = '', email = '' } = pipelineUserDetails;
+        const { username = '', email = '' } = pipelineUserDetails;
+        // Previously, the transformation of the object parameter name from
+        // "fullname" to "name" was performed in the file
+        // '/common-components/data/service.js'. However, this file has
+        // been removed, but the frontend continues to receive the "fullname"
+        // parameter from the backend.
+        const name = pipelineUserDetails.fullname || pipelineUserDetails.name || '';
         setFormFields(prevState => ({
           ...prevState, name, username, email,
         }));
@@ -702,9 +708,10 @@ RegistrationPage.propTypes = {
     currentProvider: PropTypes.string,
     errorMessage: PropTypes.string,
     finishAuthUrl: PropTypes.string,
-    pipelineUserDetails: PropTypes.shape({
+    pipeline_user_details: PropTypes.shape({
       email: PropTypes.string,
       name: PropTypes.string,
+      fullname: PropTypes.string,
       firstName: PropTypes.string,
       lastName: PropTypes.string,
       username: PropTypes.string,

--- a/src/register/tests/RegistrationPage.test.jsx
+++ b/src/register/tests/RegistrationPage.test.jsx
@@ -893,7 +893,36 @@ describe('RegistrationPage', () => {
           thirdPartyAuthApiStatus: COMPLETE_STATE,
           thirdPartyAuthContext: {
             ...initialState.commonComponents.thirdPartyAuthContext,
-            pipelineUserDetails: {
+            pipeline_user_details: {
+              email: 'test@example.com',
+              username: 'test',
+              name: 'full name test',
+            },
+          },
+        },
+      });
+      store.dispatch = jest.fn(store.dispatch);
+
+      const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />)).find('RegistrationPage');
+      expect(registrationPage.find('input#email').props().value).toEqual('test@example.com');
+      expect(registrationPage.find('input#username').props().value).toEqual('test');
+      expect(registrationPage.find('input#name').props().value).toEqual('full name test');
+      expect(store.dispatch).toHaveBeenCalledWith(setUserPipelineDataLoaded(true));
+    });
+
+    it("should fill the form with data about the user of the pipeline when the parameter 'name' is absent", () => {
+      store = mockStore({
+        ...initialState,
+        register: {
+          ...initialState.register,
+          backedUpFormData: { ...registrationFormData },
+        },
+        commonComponents: {
+          ...initialState.commonComponents,
+          thirdPartyAuthApiStatus: COMPLETE_STATE,
+          thirdPartyAuthContext: {
+            ...initialState.commonComponents.thirdPartyAuthContext,
+            pipeline_user_details: {
               email: 'test@example.com',
               username: 'test',
             },
@@ -904,7 +933,7 @@ describe('RegistrationPage', () => {
 
       const registrationPage = mount(reduxWrapper(<IntlRegistrationPage {...props} />)).find('RegistrationPage');
       expect(registrationPage.find('input#email').props().value).toEqual('test@example.com');
-      expect(registrationPage.find('input#username').props().value).toEqual('test');
+      expect(registrationPage.find('input#name').props().value).toEqual('');
       expect(store.dispatch).toHaveBeenCalledWith(setUserPipelineDataLoaded(true));
     });
 


### PR DESCRIPTION
This is the [backport](https://github.com/openedx/frontend-app-authn/pull/1022) from the master

### Description

Found an issue with auto-filling fields when using third-party auth.

![screen_40](https://github.com/openedx/frontend-app-authn/assets/98233552/0277ff39-979e-4bd3-8c3a-41a14ad71514)

Autocomplete is not happening even though we are getting valid data from the backend:
![screen_41](https://github.com/openedx/frontend-app-authn/assets/98233552/c897556e-bab4-472a-830a-18a56c80da32)

Data should be taken from the `pipeline_user_details` object. The structure of this object is as follows:
```
{
    "username": "DB_1234",
    "email": "mymail@gmail.com",
    "fullname": "David Beckham",
    "first_name": "David",
    "last_name": "Beckham"
}
```

Another issue was found. This object does not have a `name` parameter. Therefore, the "Full name" field remains empty. In Olive's release, there was a [service.js](https://github.com/openedx/frontend-app-authn/blob/open-release/olive.master/src/common-components/data/service.js) file. In this file, the renaming of the parameter was performed. 

#### After

<img width="1488" alt="screen_42" src="https://github.com/openedx/frontend-app-authn/assets/98233552/de5d816d-2cf3-4dde-9ca3-6f3ded5fedfb">

All fields are filled!


* [ ] Is there adequate test coverage for your changes?
