### PR TITLE
fix: register page crashing after click on field "username"

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -131,10 +131,20 @@ class RegistrationPage extends React.Component {
 
       // Exemption for country field's value as we need to set updated value from the store.
       if (focusedField === 'country') { focusedField = ''; }
-      const { [focusedField]: _, ...registrationData } = { ...nextProps.registrationFormData, ...nextState };
-      this.setState({
-        ...registrationData,
-      });
+
+      // For username field's value as we need to wait for usernameSuggestions.
+      // Otherwise, an infinite state update loop error appears.
+      if (focusedField === 'username') {
+        this.setState({
+          ...nextProps.registrationFormData,
+          ...nextState,
+        });
+      } else {
+        const { [focusedField]: _, ...registrationData } = { ...nextProps.registrationFormData, ...nextState };
+        this.setState({
+          ...registrationData,
+        });
+      }
     }
 
     if (this.props.usernameSuggestions.length > 0 && this.state.username === '') {


### PR DESCRIPTION
### Description

The register page crashes after clicking on the field "Public username"

How to reproduce: After entering the full name, immediately switch the focus to the "Public username" field.

<img width="1497" alt="screen_48" src="https://github.com/openedx/frontend-app-authn/assets/98233552/fdf30e42-7645-4bec-8fcc-e6e2c01db529">

Getting an error

<img width="1657" alt="screen_49" src="https://github.com/openedx/frontend-app-authn/assets/98233552/4ed3e87b-0919-4a4f-876c-f290bdb53cbb">

There is no such error in Palm Release.