### PR TITLE
fix: special characters in redirect url getting decoded to space

### DIFF
--- a/src/data/utils/dataUtils.js
+++ b/src/data/utils/dataUtils.js
@@ -50,7 +50,9 @@ export const updatePathWithQueryParams = (path) => {
 };
 
 export const getAllPossibleQueryParams = (locationURl = null) => {
-  const urlParams = locationURl ? QueryString.parseUrl(locationURl).query : QueryString.parse(window.location.search);
+  const urlParams = locationURl
+    ? QueryString.parseUrl(locationURl, { decode: false }).query
+    : QueryString.parse(window.location.search, { decode: false });
   const params = {};
   Object.entries(urlParams).forEach(([key, value]) => {
     if (AUTH_PARAMS.indexOf(key) > -1) {


### PR DESCRIPTION
### Description

In registration embedded experinece, if next Url contains `+`, it gets decoded to ` ` (space) resulting in invalid redirection. This PR fixes this issue.

#### How Has This Been Tested?

locally

#### Screenshots/sandbox (optional):

Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if its not applicable.**

|Before|After|
|-------|-----|
|      |      |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
