### PR TITLE
feat: remove hydrate call

### DIFF
--- a/src/base-container/index.jsx
+++ b/src/base-container/index.jsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 
-import { getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import { breakpoints } from '@edx/paragon';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
@@ -13,10 +12,7 @@ import {
 import { AuthLargeLayout, AuthMediumLayout, AuthSmallLayout } from './components/welcome-page-layout';
 import { DEFAULT_LAYOUT, IMAGE_LAYOUT } from './data/constants';
 
-const BaseContainer = ({ children, showWelcomeBanner }) => {
-  const authenticatedUser = showWelcomeBanner ? getAuthenticatedUser() : null;
-  const username = authenticatedUser ? authenticatedUser.username : null;
-
+const BaseContainer = ({ children, showWelcomeBanner, username }) => {
   const [baseContainerVersion, setBaseContainerVersion] = useState(DEFAULT_LAYOUT);
 
   useEffect(() => {
@@ -38,18 +34,18 @@ const BaseContainer = ({ children, showWelcomeBanner }) => {
     return (
       <div className="layout">
         <MediaQuery maxWidth={breakpoints.extraSmall.maxWidth - 1}>
-          {authenticatedUser ? <AuthSmallLayout username={username} /> : <ImageExtraSmallLayout />}
+          {showWelcomeBanner ? <AuthSmallLayout username={username} /> : <ImageExtraSmallLayout />}
         </MediaQuery>
         <MediaQuery minWidth={breakpoints.small.minWidth} maxWidth={breakpoints.small.maxWidth - 1}>
-          {authenticatedUser ? <AuthSmallLayout username={username} /> : <ImageSmallLayout />}
+          {showWelcomeBanner ? <AuthSmallLayout username={username} /> : <ImageSmallLayout />}
         </MediaQuery>
         <MediaQuery minWidth={breakpoints.medium.minWidth} maxWidth={breakpoints.large.maxWidth - 1}>
-          {authenticatedUser ? <AuthMediumLayout username={username} /> : <ImageMediumLayout />}
+          {showWelcomeBanner ? <AuthMediumLayout username={username} /> : <ImageMediumLayout />}
         </MediaQuery>
         <MediaQuery minWidth={breakpoints.extraLarge.minWidth}>
-          {authenticatedUser ? <AuthLargeLayout username={username} /> : <ImageLargeLayout />}
+          {showWelcomeBanner ? <AuthLargeLayout username={username} /> : <ImageLargeLayout />}
         </MediaQuery>
-        <div className={classNames('content', { 'align-items-center mt-0': authenticatedUser })}>
+        <div className={classNames('content', { 'align-items-center mt-0': showWelcomeBanner })}>
           {children}
         </div>
       </div>
@@ -61,15 +57,15 @@ const BaseContainer = ({ children, showWelcomeBanner }) => {
       <div className="col-md-12 extra-large-screen-top-stripe" />
       <div className="layout">
         <MediaQuery maxWidth={breakpoints.small.maxWidth - 1}>
-          {authenticatedUser ? <AuthSmallLayout username={username} /> : <DefaultSmallLayout />}
+          {showWelcomeBanner ? <AuthSmallLayout username={username} /> : <DefaultSmallLayout />}
         </MediaQuery>
         <MediaQuery minWidth={breakpoints.medium.minWidth} maxWidth={breakpoints.large.maxWidth - 1}>
-          {authenticatedUser ? <AuthMediumLayout username={username} /> : <DefaultMediumLayout />}
+          {showWelcomeBanner ? <AuthMediumLayout username={username} /> : <DefaultMediumLayout />}
         </MediaQuery>
         <MediaQuery minWidth={breakpoints.extraLarge.minWidth}>
-          {authenticatedUser ? <AuthLargeLayout username={username} /> : <DefaultLargeLayout />}
+          {showWelcomeBanner ? <AuthLargeLayout username={username} /> : <DefaultLargeLayout />}
         </MediaQuery>
-        <div className={classNames('content', { 'align-items-center mt-0': authenticatedUser })}>
+        <div className={classNames('content', { 'align-items-center mt-0': showWelcomeBanner })}>
           {children}
         </div>
       </div>
@@ -79,11 +75,13 @@ const BaseContainer = ({ children, showWelcomeBanner }) => {
 
 BaseContainer.defaultProps = {
   showWelcomeBanner: false,
+  username: null,
 };
 
 BaseContainer.propTypes = {
   children: PropTypes.node.isRequired,
   showWelcomeBanner: PropTypes.bool,
+  username: PropTypes.string,
 };
 
 export default BaseContainer;

--- a/src/common-components/RedirectLogistration.jsx
+++ b/src/common-components/RedirectLogistration.jsx
@@ -9,6 +9,7 @@ import { setCookie } from '../data/utils';
 
 const RedirectLogistration = (props) => {
   const {
+    authenticatedUser,
     finishAuthUrl,
     redirectUrl,
     redirectToProgressiveProfilingPage,
@@ -52,6 +53,7 @@ const RedirectLogistration = (props) => {
           state={{
             registrationResult,
             optionalFields,
+            authenticatedUser,
           }}
           replace
         />
@@ -81,6 +83,7 @@ const RedirectLogistration = (props) => {
 };
 
 RedirectLogistration.defaultProps = {
+  authenticatedUser: {},
   educationLevel: null,
   finishAuthUrl: null,
   success: false,
@@ -94,6 +97,7 @@ RedirectLogistration.defaultProps = {
 };
 
 RedirectLogistration.propTypes = {
+  authenticatedUser: PropTypes.shape({}),
   educationLevel: PropTypes.string,
   finishAuthUrl: PropTypes.string,
   success: PropTypes.bool,

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -541,6 +541,7 @@ const RegistrationPage = (props) => {
         </Helmet>
         <RedirectLogistration
           host={host}
+          authenticatedUser={registrationResult.authenticatedUser}
           success={registrationResult.success}
           redirectUrl={registrationResult.redirectUrl}
           finishAuthUrl={finishAuthUrl}
@@ -719,6 +720,7 @@ RegistrationPage.propTypes = {
   registrationError: PropTypes.shape({}),
   registrationErrorCode: PropTypes.string,
   registrationResult: PropTypes.shape({
+    authenticatedUser: PropTypes.shape({}),
     redirectUrl: PropTypes.string,
     success: PropTypes.bool,
   }),

--- a/src/register/data/actions.js
+++ b/src/register/data/actions.js
@@ -47,9 +47,9 @@ export const registerNewUserBegin = () => ({
   type: REGISTER_NEW_USER.BEGIN,
 });
 
-export const registerNewUserSuccess = (redirectUrl, success) => ({
+export const registerNewUserSuccess = (authenticatedUser, redirectUrl, success) => ({
   type: REGISTER_NEW_USER.SUCCESS,
-  payload: { redirectUrl, success },
+  payload: { authenticatedUser, redirectUrl, success },
 
 });
 

--- a/src/register/data/sagas.js
+++ b/src/register/data/sagas.js
@@ -19,9 +19,10 @@ export function* handleNewUserRegistration(action) {
   try {
     yield put(registerNewUserBegin());
 
-    const { redirectUrl, success } = yield call(registerRequest, action.payload.registrationInfo);
+    const { authenticatedUser, redirectUrl, success } = yield call(registerRequest, action.payload.registrationInfo);
 
     yield put(registerNewUserSuccess(
+      camelCaseObject(authenticatedUser),
       redirectUrl,
       success,
     ));

--- a/src/register/data/service.js
+++ b/src/register/data/service.js
@@ -21,6 +21,7 @@ export async function registerRequest(registrationInformation) {
   return {
     redirectUrl: data.redirect_url || `${getConfig().LMS_BASE_URL}/dashboard`,
     success: data.success || false,
+    authenticatedUser: data.authenticated_user,
   };
 }
 

--- a/src/register/data/tests/sagas.test.js
+++ b/src/register/data/tests/sagas.test.js
@@ -129,7 +129,12 @@ describe('handleNewUserRegistration', () => {
   });
 
   it('should call service and dispatch success action', async () => {
-    const data = { redirectUrl: '/dashboard', success: true };
+    const authenticatedUser = { username: 'test', user_id: 123 };
+    const data = {
+      redirectUrl: '/dashboard',
+      success: true,
+      authenticatedUser,
+    };
     const registerRequest = jest.spyOn(api, 'registerRequest')
       .mockImplementation(() => Promise.resolve(data));
 
@@ -143,7 +148,7 @@ describe('handleNewUserRegistration', () => {
     expect(registerRequest).toHaveBeenCalledTimes(1);
     expect(dispatched).toEqual([
       actions.registerNewUserBegin(),
-      actions.registerNewUserSuccess(data.redirectUrl, data.success),
+      actions.registerNewUserSuccess(camelCaseObject(authenticatedUser), data.redirectUrl, data.success),
     ]);
     registerRequest.mockClear();
   });


### PR DESCRIPTION
### Description

- Removed hydrate authenticated user call from the progressive profiling page and replaced the authenticated user with the details returned by the registration response
- Updated base container to use the username provided by the registration response. Removed extra call for it.

#### JIRA

[VAN-1580](https://2u-internal.atlassian.net/browse/VAN-1580)

#### How Has This Been Tested?

Updated tests

#### Screenshots/sandbox (optional):

No design changes in this PR.
