### PR TITLE
feat: implement SHOW_REGISTRATION_LINKS setting

### DIFF
--- a/src/common-components/EnterpriseSSO.jsx
+++ b/src/common-components/EnterpriseSSO.jsx
@@ -19,7 +19,8 @@ import { LOGIN_PAGE, SUPPORTED_ICON_CLASSES } from '../data/constants';
 const EnterpriseSSO = (props) => {
   const { formatMessage } = useIntl();
   const tpaProvider = props.provider;
-  const disablePublicAccountCreation = getConfig().ALLOW_PUBLIC_ACCOUNT_CREATION === false;
+  const disablePublicAccountCreation = getConfig().ALLOW_PUBLIC_ACCOUNT_CREATION === false
+    || getConfig().SHOW_REGISTRATION_LINKS === false;
 
   const handleSubmit = (e, url) => {
     e.preventDefault();

--- a/src/logistration/Logistration.jsx
+++ b/src/logistration/Logistration.jsx
@@ -38,7 +38,8 @@ const Logistration = (props) => {
   const [institutionLogin, setInstitutionLogin] = useState(false);
   const [key, setKey] = useState('');
   const navigate = useNavigate();
-  const disablePublicAccountCreation = getConfig().ALLOW_PUBLIC_ACCOUNT_CREATION === false;
+  const disablePublicAccountCreation = getConfig().ALLOW_PUBLIC_ACCOUNT_CREATION === false
+    || getConfig().SHOW_REGISTRATION_LINKS === false;
 
   useEffect(() => {
     const authService = getAuthService();


### PR DESCRIPTION
### Description

This PR implements the newly added [SHOW_REGISTRATION_LINKS setting](https://github.com/openedx/edx-platform/pull/32783) whose purpose is to hide the public registration functionality without disabling the register API. 

`ALLOW_PUBLIC_ACCOUNT_CREATION` is already taken into account in the `frontend-app-authn` and is expected to be set through the [runtime configuration](https://github.com/openedx/frontend-app-authn/pull/779#discussion_r1138185861).

This PR introduces the possibility of adding the `SHOW_REGISTRATION_LINKS` setting to the MFE runtime config so it can be taken into account for hiding the register functionality without disabling the API, thus [replicating the legacy LMS flow](https://github.com/openedx/edx-platform/pull/32783#issuecomment-1702579527).


#### How Has This Been Tested?
The steps to test are as follows:
1. LMS configuration:
    - Set `ENABLE_MFE_CONFIG_API` to True in the LMS settings
    - Set `SHOW_REGISTRATION_LINKS` to False in the `MFE_CONFIG` dict in the LMS settings
2. frontend-app-authn configuration:
   - set `MFE_CONFIG_API_URL` to 'http://localhost:18000/api/mfe_config/v1' in `.env.development` to enable runtime conf
3. Launch LMS + frontend-app-authn in Devstack
4. Head to http://localhost:1999/login. There should be no `register` tab.

NB: mind the `MFE_CONFIG_API_CACHE_TIMEOUT` setting if you want to play around with `MFE_CONFIG`. The result is cached for 5min by default.  The runtime config also relies on client-side [caching](https://github.com/openedx/frontend-platform/blob/93ea5b25423e8b607fb1c8633778503d76f47509/src/initialize.js#L174), so better to rely on private browsing if there is a config change.

#### Screenshots/sandbox (optional):

Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if its not applicable.**

|Before|After|
|-------|-----|
|  <img width="286" alt="image" src="https://github.com/openedx/frontend-app-authn/assets/28169169/eb2a574b-111b-4e6f-a854-d3ffee980a55">    |  <img width="265" alt="image" src="https://github.com/openedx/frontend-app-authn/assets/28169169/6602c1e9-1a0f-4a43-81d0-ea2067d66188">   |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
