### PR TITLE
fix: Missed favicon in Safari (backport from master)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
       <title>Authn | <%= process.env.SITE_NAME %></title>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon" />
       <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.6/iframeResizer.contentWindow.min.js"
               integrity="sha512-R7Piufj0/o6jG9ZKrAvS2dblFr2kkuG4XVQwStX+/4P+KwOLUXn2DXy0l1AJDxxqGhkM/FJllZHG2PKOAheYzg=="
               crossorigin="anonymous"


### PR DESCRIPTION
### Description

The favicon is not currently displaying in Safari. After our investigation, we have found a way to fix it. We used the same approach as what was done in the account mfe. We added the favicon inclusion to the index.html file, and now the favicon is being displayed in Safari.

<img width="1840" alt="Снимок экрана 2023-10-13 в 17 35 26" src="https://github.com/openedx/frontend-app-authn/assets/19806032/23d755cd-8654-43a5-adf8-d864e9dde6c8">

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
