### PR TITLE
fix: Enabling the ability to log in with a username consisting of 2 c…

### DIFF
--- a/src/i18n/messages/ar.json
+++ b/src/i18n/messages/ar.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "كلمة مرورك الحالية لا تستسجيب لمتطلبات الأمان الجديدة. لقد أرسلنا للتو رسالة لإعادة ضبط كلمة المرور إلى عنوان البريد الإلكتروني المرتبط بهذا الحساب. شكرًا لك على مساعدتنا في الحفاظ على سلامة بياناتك.",
   "account.locked.out.message.1": "لحماية حسابك، تم إقفاله مؤقتًا. حاول مرة أخرى بعد 30 دقيقة.",
   "enterprise.login.btn.text": "بيانات الشركة أو المدرسة",
-  "username.or.email.format.validation.less.chars.message": "يجب أن يحتوي اسم المستخدم أو البريد الإلكتروني على 3 أحرف على الأقل.",
+  "username.or.email.format.validation.less.chars.message": "يجب أن يحتوي اسم المستخدم أو البريد الإلكتروني على 2 أحرف على الأقل.",
   "email.validation.message": "أدخل اسم المستخدم أو البريد الإلكتروني الخاص بك",
   "password.validation.message": "لم يتم استيفاء معايير كلمة المرور",
   "account.activation.success.message.title": "نجح الأمر! لقد قمت بتفعيل حسابك.",

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "Your current password does not meet the new security requirements. We just sent a password-reset message to the email address associated with this account. Thank you for helping us keep your data safe.",
   "account.locked.out.message.1": "To protect your account, it's been temporarily locked. Try again in 30 minutes.",
   "enterprise.login.btn.text": "Company or school credentials",
-  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 3 characters.",
+  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 2 characters.",
   "email.validation.message": "Enter your username or email",
   "password.validation.message": "Password criteria has not been met",
   "account.activation.success.message.title": "Success! You have activated your account.",

--- a/src/i18n/messages/de_DE.json
+++ b/src/i18n/messages/de_DE.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "Ihr aktuelles Passwort entspricht nicht den neuen Sicherheitsanforderungen. Wir haben gerade eine Nachricht zum Zurücksetzen des Passworts an die mit diesem Konto verknüpfte E-Mail-Adresse gesendet. Vielen Dank, dass Sie uns helfen, Ihre Daten zu schützen.",
   "account.locked.out.message.1": "Um Ihr Konto zu schützen, wurde es vorübergehend gesperrt. Versuchen Sie es in 30 Minuten erneut.",
   "enterprise.login.btn.text": "Arbeits- oder Schulzeugnisse",
-  "username.or.email.format.validation.less.chars.message": "Benutzername oder E-Mail müssen mindestens 3 Zeichen lang sein.",
+  "username.or.email.format.validation.less.chars.message": "Benutzername oder E-Mail müssen mindestens 2 Zeichen lang sein.",
   "email.validation.message": "Geben Sie Ihren Benutzernamen oder Ihre E-Mail-Adresse ein",
   "password.validation.message": "Die Passwortkriterien wurden nicht erfüllt",
   "account.activation.success.message.title": "Super! Sie haben Ihr Konto aktiviert.",

--- a/src/i18n/messages/es_419.json
+++ b/src/i18n/messages/es_419.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "Tu contraseña actual no cumple con los nuevos requisitos de seguridad. Acabamos de enviar un mensaje de restablecimiento de contraseña a la dirección de correo electrónico asociada a esta cuenta. Gracias por ayudarnos a mantener tus datos seguros.",
   "account.locked.out.message.1": "Para proteger tu cuenta, se ha bloqueado temporalmente. Inténtalo de nuevo en 30 minutos.",
   "enterprise.login.btn.text": "Credenciales de la empresa o de la institución ",
-  "username.or.email.format.validation.less.chars.message": "El nombre de usuario o el correo electrónico deben tener al menos 3 caracteres.",
+  "username.or.email.format.validation.less.chars.message": "El nombre de usuario o el correo electrónico deben tener al menos 2 caracteres.",
   "email.validation.message": "Introduce tu nombre de usuario o correo electrónico",
   "password.validation.message": "No se han cumplido los criterios de la contraseña",
   "account.activation.success.message.title": "Ha sido un éxito. Has activado tu cuenta.",

--- a/src/i18n/messages/fa_IR.json
+++ b/src/i18n/messages/fa_IR.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "گذرواژه فعلی شما الزامات امنیتی جدید را برآورده نمی‌کند. ما فقط یک پیام بازتنظیم گذرواژه به نشانی رایانامه مرتبط با این حساب کاربری ارسال کردیم. از اینکه به ما کمک می‌کنید تا داده‌های شما را ایمن نگه دارید متشکریم.",
   "account.locked.out.message.1": "حساب کاربری شما، به دلیل حفاظت، به‌طور موقت قفل شده است. 30 دقیقه دیگر دوباره امتحان کنید.",
   "enterprise.login.btn.text": "اعتبار دانشکده یا شرکت",
-  "username.or.email.format.validation.less.chars.message": "نام کاربری یا نشانی رایانامه حداقل باید 3 نویسه داشته باشد",
+  "username.or.email.format.validation.less.chars.message": "نام کاربری یا نشانی رایانامه حداقل باید 2 نویسه داشته باشد",
   "email.validation.message": "نام کاربری یا رایانامه خود را وارد کنید",
   "password.validation.message": "معیارهای گذرواژه رعایت نشده است",
   "account.activation.success.message.title": "موفق شدید! شما حساب کاربری خود را فعال کردید.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "Votre mot de passe actuel ne répond pas aux nouvelles exigences de sécurité. Nous venons d'envoyer un message de réinitialisation de mot de passe à l'adresse courriel associée à ce compte. Merci de nous aider à protéger vos données.",
   "account.locked.out.message.1": "Pour protéger votre compte, il a été temporairement verrouillé. Réessayez dans 30 minutes.",
   "enterprise.login.btn.text": "Identifiants de la compagnie ou de l'école",
-  "username.or.email.format.validation.less.chars.message": "Le nom d'utilisateur ou l'adresse courriel doit comporter au moins 3 caractères.",
+  "username.or.email.format.validation.less.chars.message": "Le nom d'utilisateur ou l'adresse courriel doit comporter au moins 2 caractères.",
   "email.validation.message": "Entrez votre nom d'utilisateur ou votre adresse courriel",
   "password.validation.message": "Les critères de mot de passe n'ont pas été remplis",
   "account.activation.success.message.title": "Succès! Vous avez activé votre compte.",

--- a/src/i18n/messages/fr_CA.json
+++ b/src/i18n/messages/fr_CA.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "Votre mot de passe actuel ne répond pas aux nouvelles exigences de sécurité. Nous venons d'envoyer un message de réinitialisation de mot de passe à l'adresse courriel associée à ce compte. Merci de nous aider à protéger vos données.",
   "account.locked.out.message.1": "Pour protéger votre compte, il a été temporairement verrouillé. Réessayez dans 30 minutes.",
   "enterprise.login.btn.text": "Informations d'identification de la compagnie ou de l'école",
-  "username.or.email.format.validation.less.chars.message": "Le nom d'utilisateur ou l'adresse courriel doit comporter au moins 3 caractères.",
+  "username.or.email.format.validation.less.chars.message": "Le nom d'utilisateur ou l'adresse courriel doit comporter au moins 2 caractères.",
   "email.validation.message": "Entrez votre nom d'utilisateur ou votre adresse courriel",
   "password.validation.message": "Les critères de mot de passe n'ont pas été remplis",
   "account.activation.success.message.title": "Succès! Vous avez activé votre compte.",

--- a/src/i18n/messages/hi.json
+++ b/src/i18n/messages/hi.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "Your current password does not meet the new security requirements. We just sent a password-reset message to the email address associated with this account. Thank you for helping us keep your data safe.",
   "account.locked.out.message.1": "To protect your account, it's been temporarily locked. Try again in 30 minutes.",
   "enterprise.login.btn.text": "Company or school credentials",
-  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 3 characters.",
+  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 2 characters.",
   "email.validation.message": "Enter your username or email",
   "password.validation.message": "Password criteria has not been met",
   "account.activation.success.message.title": "Success! You have activated your account.",

--- a/src/i18n/messages/it.json
+++ b/src/i18n/messages/it.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "Your current password does not meet the new security requirements. We just sent a password-reset message to the email address associated with this account. Thank you for helping us keep your data safe.",
   "account.locked.out.message.1": "To protect your account, it's been temporarily locked. Try again in 30 minutes.",
   "enterprise.login.btn.text": "Company or school credentials",
-  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 3 characters.",
+  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 2 characters.",
   "email.validation.message": "Enter your username or email",
   "password.validation.message": "Password criteria has not been met",
   "account.activation.success.message.title": "Success! You have activated your account.",

--- a/src/i18n/messages/it_IT.json
+++ b/src/i18n/messages/it_IT.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "La tua password attuale non soddisfa i nuovi requisiti di sicurezza. Abbiamo appena inviato un messaggio di reimpostazione della password all&#39;indirizzo e-mail associato a questo account. Grazie per averci aiutato a mantenere i tuoi dati al sicuro.",
   "account.locked.out.message.1": "Per proteggere il tuo account, è stato temporaneamente bloccato. Riprova tra 30 minuti.",
   "enterprise.login.btn.text": "Credenziali aziendali o scolastiche",
-  "username.or.email.format.validation.less.chars.message": "Il nome utente o l&#39;e-mail deve contenere almeno 3 caratteri.",
+  "username.or.email.format.validation.less.chars.message": "Il nome utente o l&#39;e-mail deve contenere almeno 2 caratteri.",
   "email.validation.message": "Inserisci il tuo nome utente o e-mail",
   "password.validation.message": "I criteri della password non sono stati soddisfatti",
   "account.activation.success.message.title": "Completato correttamente! Hai attivato il tuo account. ",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "Your current password does not meet the new security requirements. We just sent a password-reset message to the email address associated with this account. Thank you for helping us keep your data safe.",
   "account.locked.out.message.1": "To protect your account, it's been temporarily locked. Try again in 30 minutes.",
   "enterprise.login.btn.text": "Company or school credentials",
-  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 3 characters.",
+  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 2 characters.",
   "email.validation.message": "Enter your username or email",
   "password.validation.message": "Password criteria has not been met",
   "account.activation.success.message.title": "Success! You have activated your account.",

--- a/src/i18n/messages/pt_PT.json
+++ b/src/i18n/messages/pt_PT.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "A sua palavra-passe atual não satisfaz os novos requisitos de segurança. Acabámos de enviar uma mensagem de redefinição da palavra-passe para o endereço de email associado a esta conta. Obrigado por nos ajudar a manter os seus dados em segurança.",
   "account.locked.out.message.1": "Para proteger sua conta, esta foi temporariamente bloqueada. Tente novamente dentro de 30 minutos.",
   "enterprise.login.btn.text": "Credenciais da empresa ou escola",
-  "username.or.email.format.validation.less.chars.message": "O nome de utilizador ou email deve ter pelo menos 3 carateres.",
+  "username.or.email.format.validation.less.chars.message": "O nome de utilizador ou email deve ter pelo menos 2 carateres.",
   "email.validation.message": "Insira o seu nome de utilizador ou email",
   "password.validation.message": "Os critérios de palavra-passe não foram cumpridos",
   "account.activation.success.message.title": "Sucesso! Você ativou a sua conta.",

--- a/src/i18n/messages/ru.json
+++ b/src/i18n/messages/ru.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "Your current password does not meet the new security requirements. We just sent a password-reset message to the email address associated with this account. Thank you for helping us keep your data safe.",
   "account.locked.out.message.1": "To protect your account, it's been temporarily locked. Try again in 30 minutes.",
   "enterprise.login.btn.text": "Company or school credentials",
-  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 3 characters.",
+  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 2 characters.",
   "email.validation.message": "Enter your username or email",
   "password.validation.message": "Password criteria has not been met",
   "account.activation.success.message.title": "Success! You have activated your account.",

--- a/src/i18n/messages/uk.json
+++ b/src/i18n/messages/uk.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "Your current password does not meet the new security requirements. We just sent a password-reset message to the email address associated with this account. Thank you for helping us keep your data safe.",
   "account.locked.out.message.1": "To protect your account, it's been temporarily locked. Try again in 30 minutes.",
   "enterprise.login.btn.text": "Company or school credentials",
-  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 3 characters.",
+  "username.or.email.format.validation.less.chars.message": "Username or email must have at least 2 characters.",
   "email.validation.message": "Enter your username or email",
   "password.validation.message": "Password criteria has not been met",
   "account.activation.success.message.title": "Success! You have activated your account.",

--- a/src/i18n/messages/zh_CN.json
+++ b/src/i18n/messages/zh_CN.json
@@ -71,7 +71,7 @@
   "non.compliant.password.message": "您当前的密码不符合新的安全要求。我们刚刚向与此帐户关联的电子邮件地址发送了密码重置邮件。感谢您帮助我们保护您的数据安全。",
   "account.locked.out.message.1": "为了保护您的帐户，它已被暂时锁定。请在 30 分钟后重试。",
   "enterprise.login.btn.text": "单位或学校证书",
-  "username.or.email.format.validation.less.chars.message": "用户名或电子邮件必须至少包含 3 个字符。",
+  "username.or.email.format.validation.less.chars.message": "用户名或电子邮件必须至少包含 2 个字符。",
   "email.validation.message": "输入您的用户名或电子邮件",
   "password.validation.message": "未满足密码条件",
   "account.activation.success.message.title": "成功！您已激活您的帐户。",

--- a/src/login/LoginPage.jsx
+++ b/src/login/LoginPage.jsx
@@ -147,7 +147,7 @@ class LoginPage extends React.Component {
 
     if (email === '') {
       errors.emailOrUsername = this.props.intl.formatMessage(messages['email.validation.message']);
-    } else if (email.length < 3) {
+    } else if (email.length < 2) {
       errors.emailOrUsername = this.props.intl.formatMessage(messages['username.or.email.format.validation.less.chars.message']);
     } else {
       errors.emailOrUsername = '';

--- a/src/login/messages.jsx
+++ b/src/login/messages.jsx
@@ -71,8 +71,8 @@ const messages = defineMessages({
   },
   'username.or.email.format.validation.less.chars.message': {
     id: 'username.or.email.format.validation.less.chars.message',
-    defaultMessage: 'Username or email must have at least 3 characters.',
-    description: 'Validation message that appears when username or email address is less than 3 characters',
+    defaultMessage: 'Username or email must have at least 2 characters.',
+    description: 'Validation message that appears when username or email address is less than 2 characters',
   },
   'email.validation.message': {
     id: 'email.validation.message',

--- a/src/login/tests/LoginPage.test.jsx
+++ b/src/login/tests/LoginPage.test.jsx
@@ -128,14 +128,14 @@ describe('LoginPage', () => {
     expect(store.dispatch).toHaveBeenCalledWith(loginRequestFailure({ errorCode: 'invalid-form' }));
   });
 
-  it('should match state for invalid email (less than 3 characters), on form submission', () => {
-    const errorState = { emailOrUsername: 'Username or email must have at least 3 characters.', password: '' };
+  it('should match state for invalid email (less than 2 characters), on form submission', () => {
+    const errorState = { emailOrUsername: 'Username or email must have at least 2 characters.', password: '' };
     store.dispatch = jest.fn(store.dispatch);
 
     const loginPage = (mount(reduxWrapper(<IntlLoginPage {...props} />))).find('LoginPage');
 
     loginPage.find('input#password').simulate('change', { target: { value: 'test', name: 'password' } });
-    loginPage.find('input#emailOrUsername').simulate('change', { target: { value: 'te', name: 'email' } });
+    loginPage.find('input#emailOrUsername').simulate('change', { target: { value: 't', name: 'email' } });
     loginPage.find('button.btn-brand').simulate('click');
 
     expect(loginPage.state('errors')).toEqual(errorState);


### PR DESCRIPTION
This is backport from master - https://github.com/openedx/frontend-app-authn/pull/1073

### Description

For now, we have the ability to register with a username consisting of 2 characters. However, when we try to log in with this username, we receive an error indicating that the 'username should be at least 3 characters.' In this PR, we fix this bug.

#### Before

https://github.com/openedx/frontend-app-authn/assets/19806032/66b9b731-f797-4a7c-bb88-48fb34b45b48

https://github.com/openedx/frontend-app-authn/assets/19806032/0a36a6b9-d0e9-4c04-867b-8f91443262c2


#### After

https://github.com/openedx/frontend-app-authn/assets/19806032/551a16cd-ed94-4e38-ae2d-fc320e177759