### PR TITLE
fix: form submission when country is not requried

### DIFF
--- a/src/register/data/utils.js
+++ b/src/register/data/utils.js
@@ -1,4 +1,4 @@
-import { snakeCaseObject } from '@edx/frontend-platform';
+import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
 
 import { LETTER_REGEX, NUMBER_REGEX } from '../../data/constants';
 import messages from '../messages';
@@ -44,11 +44,12 @@ export const isFormValid = (
     }
   });
 
-  if (!configurableFormFields?.country?.displayValue) {
-    fieldErrors.country = formatMessage(messages['empty.country.field.error']);
-    isValid = false;
+  if (getConfig().SHOW_CONFIGURABLE_EDX_FIELDS) {
+    if (!configurableFormFields?.country?.displayValue) {
+      fieldErrors.country = formatMessage(messages['empty.country.field.error']);
+      isValid = false;
+    }
   }
-
   Object.keys(fieldDescriptions).forEach(key => {
     if (key === 'country' && !configurableFormFields.country.displayValue) {
       fieldErrors[key] = formatMessage(messages['empty.country.field.error']);


### PR DESCRIPTION

### Description

  When country is not required to submit, the displayValue check
  will always return true. This fixes it by only check it if it's
  needed through the config `SHOW_CONFIGURABLE_EDX_FIELDS`

  This issue might has been discoverd at edx.org becuase edx.org
  requires the Country to be filled when creating an account,
  however this is not the case for Open edX by default, hence the
  issue reported below

  Ref: openedx/wg-build-test-release/issues/318
  



#### How Has This Been Tested?

Please describe in detail how you tested your changes.

You would need to locally install tutor and tutor-mfe `quince` branch and then try to recreate an account after all services has been inits. And lastly rebuild the MFE image using my fork as a base and you should then be able to create an account

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Backport to it to quicne.master
