### PR TITLE
fix: add spinner while fetching the optional fields in embedded exp

### DIFF
--- a/src/progressive-profiling/ProgressiveProfiling.jsx
+++ b/src/progressive-profiling/ProgressiveProfiling.jsx
@@ -14,6 +14,7 @@ import {
   Alert,
   Form,
   Hyperlink,
+  Spinner,
   StatefulButton,
 } from '@edx/paragon';
 import { Error } from '@edx/paragon/icons';
@@ -217,57 +218,63 @@ const ProgressiveProfiling = (props) => {
         />
       )}
       <div className="mw-xs m-4 pp-page-content">
-        <div>
-          <h2 className="pp-page__heading text-primary">{formatMessage(messages['progressive.profiling.page.heading'])}</h2>
-        </div>
-        <hr className="border-light-700 mb-4" />
-        {showError ? (
-          <Alert id="pp-page-errors" className="mb-3" variant="danger" icon={Error}>
-            <Alert.Heading>{formatMessage(messages['welcome.page.error.heading'])}</Alert.Heading>
-            <p>{formatMessage(messages['welcome.page.error.message'])}</p>
-          </Alert>
-        ) : null}
-        <Form>
-          {formFields}
-          {(getConfig().AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK) && (
-            <span className="pp-page__support-link">
-              <Hyperlink
-                isInline
-                variant="muted"
-                destination={getConfig().AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK}
-                target="_blank"
-                showLaunchIcon={false}
-                onClick={() => (sendTrackEvent('edx.bi.welcome.page.support.link.clicked'))}
-              >
-                {formatMessage(messages['optional.fields.information.link'])}
-              </Hyperlink>
-            </span>
-          )}
-          <div className="d-flex mt-4 mb-3">
-            <StatefulButton
-              type="submit"
-              variant="brand"
-              className="pp-page__button-width"
-              state={submitState}
-              labels={{
-                default: showRecommendationsPage ? formatMessage(messages['optional.fields.next.button']) : formatMessage(messages['optional.fields.submit.button']),
-                pending: '',
-              }}
-              onClick={handleSubmit}
-              onMouseDown={(e) => e.preventDefault()}
-            />
-            <StatefulButton
-              className="text-gray-700 font-weight-500"
-              type="submit"
-              variant="link"
-              labels={{
-                default: formatMessage(messages['optional.fields.skip.button']),
-              }}
-              onClick={handleSkip}
-              onMouseDown={(e) => e.preventDefault()}
-            />
-          </div>
-        </Form>
+        {registrationEmbedded && welcomePageContextApiStatus === PENDING_STATE ? (
+          <Spinner animation="border" variant="primary" id="tpa-spinner" />
+        ) : (
+          <>
+            <div>
+              <h2 className="pp-page__heading text-primary">{formatMessage(messages['progressive.profiling.page.heading'])}</h2>
+            </div><hr className="border-light-700 mb-4" />
+            {showError ? (
+              <Alert id="pp-page-errors" className="mb-3" variant="danger" icon={Error}>
+                <Alert.Heading>{formatMessage(messages['welcome.page.error.heading'])}</Alert.Heading>
+                <p>{formatMessage(messages['welcome.page.error.message'])}</p>
+              </Alert>
+            ) : null}
+            <Form>
+              {formFields}
+              {(getConfig().AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK) && (
+                <span className="pp-page__support-link">
+                  <Hyperlink
+                    isInline
+                    variant="muted"
+                    destination={getConfig().AUTHN_PROGRESSIVE_PROFILING_SUPPORT_LINK}
+                    target="_blank"
+                    showLaunchIcon={false}
+                    onClick={() => (sendTrackEvent('edx.bi.welcome.page.support.link.clicked'))}
+                  >
+                    {formatMessage(messages['optional.fields.information.link'])}
+                  </Hyperlink>
+                </span>
+              )}
+              <div className="d-flex mt-4 mb-3">
+                <StatefulButton
+                  type="submit"
+                  variant="brand"
+                  className="pp-page__button-width"
+                  state={submitState}
+                  labels={{
+                    default: showRecommendationsPage ? formatMessage(messages['optional.fields.next.button']) : formatMessage(messages['optional.fields.submit.button']),
+                    pending: '',
+                  }}
+                  onClick={handleSubmit}
+                  onMouseDown={(e) => e.preventDefault()}
+                />
+                <StatefulButton
+                  className="text-gray-700 font-weight-500"
+                  type="submit"
+                  variant="link"
+                  labels={{
+                    default: formatMessage(messages['optional.fields.skip.button']),
+                  }}
+                  onClick={handleSkip}
+                  onMouseDown={(e) => e.preventDefault()}
+                />
+              </div>
+            </Form>
+          </>
+        )}
+
       </div>
     </BaseContainer>
   );

--- a/src/progressive-profiling/tests/ProgressiveProfiling.test.jsx
+++ b/src/progressive-profiling/tests/ProgressiveProfiling.test.jsx
@@ -14,6 +14,7 @@ import {
   COMPLETE_STATE, DEFAULT_REDIRECT_URL,
   EMBEDDED,
   FAILURE_STATE,
+  PENDING_STATE,
   RECOMMENDATIONS,
 } from '../../data/constants';
 import { saveUserProfile } from '../data/actions';
@@ -290,6 +291,28 @@ describe('ProgressiveProfilingTests', () => {
 
       progressiveProfilingPage.find('button.btn-link').simulate('click');
       expect(sendTrackEvent).toHaveBeenCalledWith('edx.bi.welcome.page.skip.link.clicked', { host });
+    });
+
+    it('should show spinner while fetching the optional fields', () => {
+      delete window.location;
+      window.location = {
+        assign: jest.fn().mockImplementation((value) => { window.location.href = value; }),
+        href: getConfig().BASE_URL.concat(AUTHN_PROGRESSIVE_PROFILING),
+        search: `?host=${host}&variant=${EMBEDDED}`,
+      };
+
+      store = mockStore({
+        ...initialState,
+        commonComponents: {
+          ...initialState.commonComponents,
+          thirdPartyAuthApiStatus: PENDING_STATE,
+          optionalFields,
+        },
+      });
+
+      const progressiveProfilingPage = mount(reduxWrapper(<IntlProgressiveProfilingPage />));
+
+      expect(progressiveProfilingPage.find('#tpa-spinner').exists()).toBeTruthy();
     });
 
     it('should set host property value to host where iframe is embedded for on ramp experience', () => {


### PR DESCRIPTION
Description:
Add spinner while fetching the optional fields in embedded exp 

[VAN-1658](https://2u-internal.atlassian.net/browse/VAN-1658)

How Has This Been Tested?
It has been tested locally.


**Before**

https://github.com/openedx/frontend-app-authn/assets/12580995/164a2992-6885-4cf4-9c54-003372710f2e

**After**

https://github.com/openedx/frontend-app-authn/assets/12580995/bf5b09f4-4da7-45e7-bc74-5b5ec25d7e5c

 
