### PR TITLE
fix: Fixed spacing in tablet version (quince.master)

### DIFF
--- a/src/base-container/components/default-layout/MediumLayout.jsx
+++ b/src/base-container/components/default-layout/MediumLayout.jsx
@@ -27,9 +27,11 @@ const MediumLayout = () => {
                   { 'ml-4.5': getConfig().SITE_NAME !== 'edX' },
                 )}
               >
-                <span className="mr-2">{formatMessage(messages['start.learning'])}</span>
-                <span className="text-accent-a d-inline-block">
-                  {formatMessage(messages['with.site.name'], { siteName: getConfig().SITE_NAME })}
+                <span>
+                  {formatMessage(messages['start.learning'])}{' '}
+                  <span className="text-accent-a d-inline-block">
+                    {formatMessage(messages['with.site.name'], { siteName: getConfig().SITE_NAME })}
+                  </span>
                 </span>
               </h1>
             </div>

--- a/src/base-container/components/default-layout/SmallLayout.jsx
+++ b/src/base-container/components/default-layout/SmallLayout.jsx
@@ -26,8 +26,8 @@ const SmallLayout = () => {
             )}
           >
             <span>
-              {formatMessage(messages['start.learning'])}
-              <span className="text-accent-a d-inline-block">{' '}
+              {formatMessage(messages['start.learning'])}{' '}
+              <span className="text-accent-a d-inline-block">
                 {formatMessage(messages['with.site.name'], { siteName: getConfig().SITE_NAME })}
               </span>
             </span>

--- a/src/base-container/components/default-layout/SmallLayout.jsx
+++ b/src/base-container/components/default-layout/SmallLayout.jsx
@@ -25,9 +25,11 @@ const SmallLayout = () => {
               { 'ml-4.5': getConfig().SITE_NAME !== 'edX' },
             )}
           >
-            <span className="mr-1">{formatMessage(messages['start.learning'])}</span>
-            <span className="text-accent-a d-inline-block">
-              {formatMessage(messages['with.site.name'], { siteName: getConfig().SITE_NAME })}
+            <span>
+              {formatMessage(messages['start.learning'])}
+              <span className="text-accent-a d-inline-block">{' '}
+                {formatMessage(messages['with.site.name'], { siteName: getConfig().SITE_NAME })}
+              </span>
             </span>
           </h1>
         </div>


### PR DESCRIPTION
### Fixed spacing in tablet version

Fixed spacing in authn title in tablet version

#### Screenshots/sandbox (optional):

![Screenshot 2023-09-19 at 12 52 15](https://github.com/openedx/frontend-app-authn/assets/138868841/e9cd600e-8589-4231-b902-c465492d7a03)