### PR TITLE
feat: tutor-mfe compatiblilty for atlas pull | FC-0012 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,11 +53,12 @@ pull_translations:
 	rm -rf src/i18n/messages
 	mkdir src/i18n/messages
 	cd src/i18n/messages \
-	  && atlas pull --filter=$(transifex_langs) \
+	  && atlas pull $(ATLAS_OPTIONS) \
 	           translations/paragon/src/i18n/messages:paragon \
+	           translations/frontend-platform/src/i18n/messages:frontend-platform \
 	           translations/frontend-app-authn/src/i18n/messages:frontend-app-authn
 
-	$(intl_imports) paragon frontend-app-authn
+	$(intl_imports) paragon frontend-platform frontend-app-authn
 endif
 
 # This target is used by Travis.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@edx/frontend-platform": "7.0.1",
+        "@edx/openedx-atlas": "^0.6.0",
         "@fortawesome/fontawesome-svg-core": "6.5.1",
         "@fortawesome/free-brands-svg-icons": "6.5.1",
         "@fortawesome/free-solid-svg-icons": "6.5.1",
@@ -2441,6 +2442,14 @@
       "integrity": "sha512-OrlvtdsPcWuOm6NBWfUxFE06qdPiu2bf9nU4I9t8Lu7WW6NsosAB5hxm5U+MBMZP2AuVl3FAt0k0lZsu3+ri8Q==",
       "dependencies": {
         "@newrelic/publish-sourcemap": "^5.0.1"
+      }
+    },
+    "node_modules/@edx/openedx-atlas": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/openedx-atlas/-/openedx-atlas-0.6.0.tgz",
+      "integrity": "sha512-wZO7hA4VJ/bXjaQNNR7KXGYyTCNs1mBJd3HwQK2EmOwFZYFNX6nzSAm9S7HCfi/kb1PCRpmp3wJt+v/Eu9BEQg==",
+      "bin": {
+        "atlas": "atlas"
       }
     },
     "node_modules/@edx/reactifex": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@edx/frontend-platform": "7.0.1",
+    "@edx/openedx-atlas": "^0.6.0",
     "@fortawesome/fontawesome-svg-core": "6.5.1",
     "@fortawesome/free-brands-svg-icons": "6.5.1",
     "@fortawesome/free-solid-svg-icons": "6.5.1",


### PR DESCRIPTION
Similar to https://github.com/openedx/frontend-app-communications/pull/187.

## Changes



 - install atlas
 - remove `--filter` to pull all languages by default
 - use ATLAS_OPTIONS to allow custom `--filter`
 - include frontend-platform in `atlas pull`

## Refs

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which implements the [Translation Infrastructure update OEP-58](https://docs.openedx.org/en/latest/developers/concepts/oep58.html).
