### PR TITLE
feat: update default authn settings

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -19,6 +19,9 @@ REFRESH_ACCESS_TOKEN_ENDPOINT='http://localhost:18000/login_refresh'
 SEGMENT_KEY=''
 SITE_NAME='Your Platform Name Here'
 INFO_EMAIL='info@example.com'
+# ***** Features *****
+ENABLE_DYNAMIC_REGISTRATION_FIELDS='true'
+ENABLE_PROGRESSIVE_PROFILING_ON_AUTHN='true'
 # ***** Cookies *****
 SESSION_COOKIE_DOMAIN='localhost'
 USER_INFO_COOKIE_NAME='edx-user-info'

--- a/src/register/data/utils.js
+++ b/src/register/data/utils.js
@@ -1,4 +1,4 @@
-import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
+import { snakeCaseObject } from '@edx/frontend-platform';
 
 import { LETTER_REGEX, NUMBER_REGEX } from '../../data/constants';
 import messages from '../messages';
@@ -44,15 +44,15 @@ export const isFormValid = (
     }
   });
 
-  if (getConfig().SHOW_CONFIGURABLE_EDX_FIELDS) {
-    if (!configurableFormFields?.country?.displayValue) {
-      fieldErrors.country = formatMessage(messages['empty.country.field.error']);
-      isValid = false;
-    } else if (!configurableFormFields?.country?.countryCode) {
-      fieldErrors.country = formatMessage(messages['invalid.country.field.error']);
-      isValid = false;
-    }
+  // Don't validate when country field is optional or hidden and not present on registration form
+  if (configurableFormFields?.country && !configurableFormFields.country?.displayValue) {
+    fieldErrors.country = formatMessage(messages['empty.country.field.error']);
+    isValid = false;
+  } else if (configurableFormFields?.country && !configurableFormFields.country?.countryCode) {
+    fieldErrors.country = formatMessage(messages['invalid.country.field.error']);
+    isValid = false;
   }
+
   Object.keys(fieldDescriptions).forEach(key => {
     if (key === 'country' && !configurableFormFields.country.displayValue) {
       fieldErrors[key] = formatMessage(messages['empty.country.field.error']);


### PR DESCRIPTION
### Description

At present, Authn MFE doesn't work out of the box with devstack settings. These changes allow authn to work with default devstack settings.

Also fixed a bug to validate country field even outside of SHOW_CONFIGURABLE_EDX_FIELDS check. 

#### How Has This Been Tested?

Locally

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
