### PR TITLE
chore: upgrade paragon to v22.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fortawesome/free-brands-svg-icons": "6.5.1",
         "@fortawesome/free-solid-svg-icons": "6.5.1",
         "@fortawesome/react-fontawesome": "0.2.0",
-        "@openedx/paragon": "^22.0.0",
+        "@openedx/paragon": "^22.1.1",
         "@optimizely/react-sdk": "^2.9.1",
         "@redux-devtools/extension": "3.3.0",
         "@testing-library/react": "^12.1.5",
@@ -5180,9 +5180,9 @@
       }
     },
     "node_modules/@openedx/paragon": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.0.0.tgz",
-      "integrity": "sha512-2tD5SEu6kNf2Llop/FylqTI87mlG0jaeAhGiX57bABcHZ/cDParCxX/unPiui6LCfdrDhghjVBKD3U2+Qn6Wag==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/@openedx/paragon/-/paragon-22.1.1.tgz",
+      "integrity": "sha512-XPRuV9zn7BeCIYfU5kE2XZ4YevjA0wfS/fuydB8Ta/aNY1dw9fQ7CjHOIfkZqDic4Jygusj/uhE/1WYJD8kvyw==",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",
         "@fortawesome/react-fontawesome": "^0.1.18",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@fortawesome/free-brands-svg-icons": "6.5.1",
     "@fortawesome/free-solid-svg-icons": "6.5.1",
     "@fortawesome/react-fontawesome": "0.2.0",
-    "@openedx/paragon": "^22.0.0",
+    "@openedx/paragon": "^22.1.1",
     "@optimizely/react-sdk": "^2.9.1",
     "@redux-devtools/extension": "3.3.0",
     "@testing-library/react": "^12.1.5",


### PR DESCRIPTION
### Description

Upgraded Paragon version to v22.1.1

**Reason:** v22.0.0 had an issue of unrecognized prop being passed to DOM which was causing multiple API calls in the MFE. For more details please look at: https://github.com/openedx/paragon/pull/3003

#### JIRA

No Jira issue

#### How Has This Been Tested?

Locally

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
