### PR TITLE
fix: browser header showing null

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en-us">
   <head>
-      <title>Authn | <%= process.env.SITE_NAME %></title>
+      <title><%= process.env.SITE_NAME ? 'Authn | ' + process.env.SITE_NAME : 'Authn' %></title>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon" />


### PR DESCRIPTION
### Description

When accessing Authn MFE for the first time it shows “Auth | null” in the browser header. In this PR we fix If process.env.SITE_NAME is not available it will show  “Authn” Otherwise show “Authn | <site name>”

#### JIRA

[VAN-1839](https://2u-internal.atlassian.net/browse/VAN-1839)

#### How Has This Been Tested?

Please describe in detail how you tested your changes.

#### Screenshots/sandbox (optional):

|Before|After|
|-------|-----|
|<img width="265" alt="Screenshot 2024-02-26 at 3 53 42 PM" src="https://github.com/openedx/frontend-app-authn/assets/7627421/7adf84eb-e7b8-49d4-ac33-032e7171b44e">|<img width="235" alt="Screenshot 2024-02-26 at 4 02 39 PM" src="https://github.com/openedx/frontend-app-authn/assets/7627421/1a416522-5c3c-4dd2-a74b-48369ca4c933">|

