### PR TITLE
fix: fix simplify registration experiment bugs

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -33,6 +33,7 @@ import {
   SECOND_STEP,
   shouldDisplayFieldInExperiment,
   SIMPLIFIED_REGISTRATION_VARIATION,
+  validateSimplifiedRegistrationFirstStepPayload,
 } from './data/optimizelyExperiment/helper';
 import {
   trackSimplifyRegistrationContinueBtnClicked,
@@ -41,7 +42,7 @@ import {
 import useSimplifyRegistrationExperimentVariation
   from './data/optimizelyExperiment/useSimplifyRegistrationExperimentVariation';
 import {
-  getBackendValidations, isFormValid, prepareRegistrationPayload, validatePasswordField,
+  getBackendValidations, isFormValid, prepareRegistrationPayload,
 } from './data/utils';
 import messages from './messages';
 import { EmailField, NameField, UsernameField } from './RegistrationFields';
@@ -305,14 +306,18 @@ const RegistrationPage = (props) => {
         formFields,
         configurableFormFields,
       );
-      // We need to explicitly validated password field because the validations for password value
-      // are different at frontend and backend.
-      const passwordFieldError = validatePasswordField(payload.password, formatMessage);
-      if (passwordFieldError) {
-        setErrors(prevErrors => ({
-          ...prevErrors,
-          password: passwordFieldError,
-        }));
+      const {
+        isValid,
+        fieldErrors,
+      } = validateSimplifiedRegistrationFirstStepPayload(payload, errors, formatMessage);
+
+      setErrors(prevErrors => ({
+        ...prevErrors,
+        ...fieldErrors,
+      }));
+      // returning if not valid
+      if (!isValid) {
+        setErrorCode(prevState => ({ type: FORM_SUBMISSION_ERROR, count: prevState.count + 1 }));
       } else {
         dispatch(fetchRealtimeValidations(payload, true));
       }

--- a/src/register/data/optimizelyExperiment/helper.js
+++ b/src/register/data/optimizelyExperiment/helper.js
@@ -4,6 +4,7 @@
 import { getConfig, snakeCaseObject } from '@edx/frontend-platform';
 
 import messages from '../../messages';
+import { validatePasswordField } from '../utils';
 
 export const DEFAULT_VARIATION = 'default-register-page';
 export const SIMPLIFIED_REGISTRATION_VARIATION = 'simplified-register-page';
@@ -77,4 +78,23 @@ export const prepareSimplifiedRegistrationFirstStepPayload = (
 
   payload = { ...payload };
   return payload;
+};
+
+export const validateSimplifiedRegistrationFirstStepPayload = (payload, errors, formatMessage) => {
+  const fieldErrors = { ...errors };
+  let isValid = true;
+  Object.keys(payload).forEach(key => {
+    if (key === 'password') {
+      // We need to explicitly validated password field because the validations for password value
+      // are different at frontend and backend.
+      fieldErrors[key] = validatePasswordField(payload[key], formatMessage);
+    } else if (!payload[key]) {
+      fieldErrors[key] = formatMessage(messages[`empty.${key}.field.error`]);
+    }
+    if (fieldErrors[key]) {
+      isValid = false;
+    }
+  });
+
+  return { isValid, fieldErrors };
 };

--- a/src/register/data/optimizelyExperiment/useSimplifyRegistrationExperimentVariation.jsx
+++ b/src/register/data/optimizelyExperiment/useSimplifyRegistrationExperimentVariation.jsx
@@ -46,7 +46,9 @@ const useSimplifyRegistrationExperimentVariation = (
     return () => {
       clearTimeout(timer);
     };
-  }, [currentProvider, initExpVariation, registrationEmbedded, thirdPartyAuthApiStatus, tpaHint, variation]);
+  }, [ // eslint-disable-line react-hooks/exhaustive-deps
+    currentProvider, initExpVariation, registrationEmbedded, thirdPartyAuthApiStatus, tpaHint,
+  ]);
 
   return variation;
 };


### PR DESCRIPTION
### Description

This PR fixes the following simplify registration experiment bugs
- frontend validations running for password field only on submit
- Step 1 viewed the event being fired twice.

#### JIRA

[VAN-1827](https://2u-internal.atlassian.net/browse/VAN-1827)

#### How Has This Been Tested?

Locally
#### Screenshots/sandbox (optional):

Include a link to the sandbox for design changes or screenshot for before and after. **Remove this section if its not applicable.**

|Before|After|
|-------|-----|
|      |      |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
