### PR TITLE
feat: add submit btn click event for default register page

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -27,6 +27,7 @@ import {
   TPA_AUTHENTICATION_FAILURE,
 } from './data/constants';
 import {
+  DEFAULT_VARIATION,
   FIRST_STEP,
   getRegisterButtonLabelInExperiment,
   NOT_INITIALIZED,
@@ -307,10 +308,13 @@ const RegistrationPage = (props) => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
+    if (simplifyRegistrationExpVariation === SIMPLIFIED_REGISTRATION_VARIATION
+        || simplifyRegistrationExpVariation === DEFAULT_VARIATION) {
+      trackSimplifyRegistrationContinueBtnClicked(simplifyRegistrationExpVariation);
+    }
 
     if (simplifyRegistrationExpVariation === SIMPLIFIED_REGISTRATION_VARIATION
         && simplifiedRegisterPageStep === FIRST_STEP) {
-      trackSimplifyRegistrationContinueBtnClicked();
       const { isValid, fieldErrors } = validateSimplifiedRegistrationFirstStepPayload(
         formFields, errors, configurableFormFields, fieldDescriptions, formatMessage,
       );

--- a/src/register/data/optimizelyExperiment/track.js
+++ b/src/register/data/optimizelyExperiment/track.js
@@ -1,11 +1,8 @@
 import { sendTrackEvent } from '@edx/frontend-platform/analytics';
 
 export const eventNames = {
-  /**
-   * sso button clicked
-   */
-  simplifyRegistrationFirstStepViewed: 'edx.bi.user.simplifyregistration.step1.viewed', // page = first/second, variation,
-  simplifyRegistrationSecondStepViewed: 'edx.bi.user.simplifyregistration.step2.viewed', // page = first/second, variation,
+  simplifyRegistrationFirstStepViewed: 'edx.bi.user.simplifyregistration.step1.viewed',
+  simplifyRegistrationSecondStepViewed: 'edx.bi.user.simplifyregistration.step2.viewed',
   simplifyRegistrationContinueBtnClicked: 'edx.bi.user.registration.submit.click',
 };
 
@@ -21,6 +18,8 @@ export const trackSimplifyRegistrationSecondStepViewed = () => {
   sendTrackEvent(eventNames.simplifyRegistrationSecondStepViewed, {});
 };
 
-export const trackSimplifyRegistrationContinueBtnClicked = () => {
-  sendTrackEvent(eventNames.simplifyRegistrationContinueBtnClicked, {});
+export const trackSimplifyRegistrationContinueBtnClicked = (expVariation) => {
+  sendTrackEvent(eventNames.simplifyRegistrationContinueBtnClicked, {
+    variation: expVariation,
+  });
 };


### PR DESCRIPTION
### Description

To compare the control and variation group for the A/B test where we are measuring the impact of removing username from registration form, added event to default "Register for free" button clicks.

#### JIRA

https://2u-internal.atlassian.net/browse/VAN-1827

#### How Has This Been Tested?

Locally
