### PR TITLE
fix: change submit cta text for experiment

### DIFF
--- a/src/register/data/optimizelyExperiment/helper.js
+++ b/src/register/data/optimizelyExperiment/helper.js
@@ -53,7 +53,7 @@ export const shouldDisplayFieldInExperiment = (fieldName, expVariation, register
 export const getRegisterButtonLabelInExperiment = (
   existingButtonLabel, expVariation, registerPageStep, formatMessage,
 ) => {
-  if (expVariation === SIMPLIFIED_REGISTRATION_VARIATION && registerPageStep === FIRST_STEP) {
+  if (expVariation === SIMPLIFIED_REGISTRATION_VARIATION && registerPageStep === SECOND_STEP) {
     return formatMessage(messages['simplified.registration.exp.button']);
   }
   return existingButtonLabel;

--- a/src/register/messages.jsx
+++ b/src/register/messages.jsx
@@ -204,7 +204,7 @@ const messages = defineMessages({
   // Simplify Registration experiment
   'simplified.registration.exp.button': {
     id: 'simplified.registration.exp.button',
-    defaultMessage: 'Continue',
+    defaultMessage: 'Complete account creation',
     description: 'Label text for simplified registration page second step',
   },
   'simplify.registration.username.guideline.content': {


### PR DESCRIPTION
### Description

Changed the CTA text for simplified registration experiment

#### How Has This Been Tested?

Locally

#### Screenshots (Simplified registration variation):

|Before|After|
|-------|-----|
| <img width="1438" alt="Screenshot 2024-02-29 at 11 10 31 AM" src="https://github.com/openedx/frontend-app-authn/assets/52817156/128e2e3d-8033-4694-80a2-b7bb373b04d8"> | <img width="1440" alt="Screenshot 2024-02-29 at 11 07 39 AM" src="https://github.com/openedx/frontend-app-authn/assets/52817156/53c8b7b8-faca-4de2-bded-a101b86aa205"> |
| <img width="1440" alt="Screenshot 2024-02-29 at 11 11 07 AM" src="https://github.com/openedx/frontend-app-authn/assets/52817156/30c4f8dd-dc21-4dfe-bb1e-335e5da83802"> | <img width="1440" alt="Screenshot 2024-02-29 at 11 07 30 AM" src="https://github.com/openedx/frontend-app-authn/assets/52817156/7cf8dfe4-d828-4d37-97b6-d8cf00f9c898"> |

#### Screenshots (Default registration variation):

|Before|After|
|-------|-----|
| <img width="1440" alt="Screenshot 2024-02-29 at 11 13 26 AM" src="https://github.com/openedx/frontend-app-authn/assets/52817156/34e180a2-2d6c-4b81-9325-45932257e510"> | <img width="1440" alt="Screenshot 2024-02-29 at 11 13 26 AM" src="https://github.com/openedx/frontend-app-authn/assets/52817156/34e180a2-2d6c-4b81-9325-45932257e510"> |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/2u-vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
