### PR TITLE
fix: browser header showing null and replace authn with Authentication

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en-us">
   <head>
-      <title><%= process.env.SITE_NAME ? 'Authn | ' + process.env.SITE_NAME : 'Authn' %></title>    
+      <title><%= (process.env.SITE_NAME && process.env.SITE_NAME != 'null') ? 'Authentication | ' + process.env.SITE_NAME : 'Authentication' %></title>    
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon"/>


### PR DESCRIPTION
### Description

When accessing Authn MFE for the first time it shows "Auth | null" in the browser header. This PR will fix If process.env.SITE_NAME is not available it will show “Authentication” otherwise show “Authentication | {site_name}”. This bug  (#1158) has been fixed in #1168 but still not resolve. As `process.env.SITE_NAME` is `null` but in `index.html`, it assumes `null` as a string value and passed the condition which is expected to be failed. As a result, still showing `Authn | null`. Moreover, in this PR, I have replaced `Authn` with the `Authentication` as suggested [here](https://github.com/openedx/frontend-app-authn/issues/1158#issuecomment-1965850295). 


#### How Has This Been Tested?

Please describe in detail how you tested your changes.

#### Screenshots/sandbox (optional):

|Before|After|
|-------|-----|
|  <img width="482" alt="auth2" src="https://github.com/openedx/frontend-app-authn/assets/112946189/af6fa9b0-9813-4d60-80c5-b70d4023f10b"> | <img width="482" alt="authn1" src="https://github.com/openedx/frontend-app-authn/assets/112946189/f175fa24-b34b-449b-aca6-535ef31ddc44">|

