### PR TITLE
fix: browser header showing null and replace authn with Authentication

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html lang="en-us">
   <head>
-      <title><%= process.env.SITE_NAME ? 'Authn | ' + process.env.SITE_NAME : 'Authn' %></title>
+      <title><%= (process.env.SITE_NAME && process.env.SITE_NAME != 'null') ? 'Authentication | ' + process.env.SITE_NAME : 'Authentication' %></title> 
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <link rel="shortcut icon" href="<%=htmlWebpackPlugin.options.FAVICON_URL%>" type="image/x-icon" />


### PR DESCRIPTION
This is backport PR of https://github.com/openedx/frontend-app-authn/pull/1185/files