### PR TITLE
fix: Authn pages - fix background on medium resolutions [master]

### DIFF
--- a/src/base-container/components/default-layout/LargeLayout.jsx
+++ b/src/base-container/components/default-layout/LargeLayout.jsx
@@ -11,8 +11,8 @@ const LargeLayout = () => {
   const { formatMessage } = useIntl();
 
   return (
-    <div className="w-50 d-flex">
-      <div className="col-md-9 bg-primary-400">
+    <div className="w-50 d-flex bg-primary-400 authn-container">
+      <div className="col-md-10">
         <Hyperlink destination={getConfig().MARKETING_SITE_BASE_URL}>
           <Image className="logo position-absolute" alt={getConfig().SITE_NAME} src={getConfig().LOGO_WHITE_URL} />
         </Hyperlink>
@@ -30,13 +30,6 @@ const LargeLayout = () => {
             </div>
           </h1>
         </div>
-      </div>
-      <div className="col-md-3 bg-white p-0">
-        <svg className="ml-n1 w-100 h-100 large-screen-svg-primary" preserveAspectRatio="xMaxYMin meet">
-          <g transform="skewX(171.6)">
-            <rect x="0" y="0" height="100%" width="100%" />
-          </g>
-        </svg>
       </div>
     </div>
   );

--- a/src/sass/_style.scss
+++ b/src/sass/_style.scss
@@ -457,3 +457,18 @@ select.form-control {
 .pgn__form-control-decorator-trailing {
   right: 0 !important;
 }
+
+.authn-container {
+  position: relative;
+
+  &:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 140px;
+    background-color: #fff;
+    clip-path: polygon(101% 0%, 0% 100%, 101% 100%);
+  }
+}


### PR DESCRIPTION
### Description

At some resolutions, we can see this bug. It's related to the SVG image having a specific height, and at certain page sizes, this height isn't enough for the SVG to reach the bottom of the page. We suggest drawing a slanted background using CSS

#### How Has This Been Tested?

Locally, in different browsers and resolutions (Screenshots below)

Before
<img width="1840" alt="Снимок экрана 2024-03-05 в 15 59 26" src="https://github.com/openedx/frontend-app-authn/assets/19806032/f70d1f93-9232-4a89-8e87-7a734b8f3b14">

After
<img width="1840" alt="Снимок экрана 2024-03-05 в 16 04 56" src="https://github.com/openedx/frontend-app-authn/assets/19806032/04cc2105-5d3d-44d7-a66c-5fa5b09fce32">

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/2u-vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
