### PR TITLE
fix: move country field to simplify registration second step

### DIFF
--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -308,12 +308,15 @@ const RegistrationPage = (props) => {
 
     if (simplifyRegistrationExpVariation === SIMPLIFIED_REGISTRATION_VARIATION
         && simplifiedRegisterPageStep === FIRST_STEP) {
-      const payload = { ...formFields };
-      // We dont want to validate username since it is in second step of registration
-      delete payload.username;
+      // We don't want to validate username and country since these are in the second step of registration
+      const { username, ...formFieldsPayload } = formFields;
+      const { country, ...configurableFormFieldsPayload } = configurableFormFields;
+      const { country: countryDescription, ...fieldDescriptionsPayload } = fieldDescriptions;
+
       const { isValid, fieldErrors } = isFormValid(
-        payload, errors, configurableFormFields, fieldDescriptions, formatMessage,
+        formFieldsPayload, errors, configurableFormFieldsPayload, fieldDescriptionsPayload, formatMessage,
       );
+
       setErrors(prevErrors => ({
         ...prevErrors,
         ...fieldErrors,

--- a/src/register/data/optimizelyExperiment/helper.js
+++ b/src/register/data/optimizelyExperiment/helper.js
@@ -13,7 +13,8 @@ export const SIMPLIFIED_REGISTRATION_VARIATION = 'simplified-register-page';
 export const FIRST_STEP = 'first-step';
 export const SECOND_STEP = 'second-step';
 
-export const SIMPLIFIED_REGISTER_PAGE_SECOND_STEP_FIELDS = ['username', 'tos_and_honor_code', 'honor_code'];
+export const SIMPLIFIED_REGISTER_PAGE_SECOND_STEP_FIELDS = ['username', 'country'];
+export const SIMPLIFIED_REGISTER_PAGE_COMMON_FIELDS = ['tos_and_honor_code', 'honor_code'];
 
 const SIMPLIFY_REGISTRATION_EXP_PAGE = 'authn_register_page';
 
@@ -45,7 +46,8 @@ export const shouldDisplayFieldInExperiment = (fieldName, expVariation, register
   !expVariation || expVariation === NOT_INITIALIZED || expVariation === DEFAULT_VARIATION
   || (expVariation === SIMPLIFIED_REGISTRATION_VARIATION
     && (
-      (registerPageStep === FIRST_STEP && fieldName !== 'username')
+      SIMPLIFIED_REGISTER_PAGE_COMMON_FIELDS.includes(fieldName)
+        || (registerPageStep === FIRST_STEP && !SIMPLIFIED_REGISTER_PAGE_SECOND_STEP_FIELDS.includes(fieldName))
       || (registerPageStep === SECOND_STEP && SIMPLIFIED_REGISTER_PAGE_SECOND_STEP_FIELDS.includes(fieldName))
     ))
 );

--- a/src/register/data/reducers.js
+++ b/src/register/data/reducers.js
@@ -55,7 +55,7 @@ const reducer = (state = defaultState, action = {}) => {
       };
     case BACKUP_REGISTRATION_DATA.BEGIN:
       return {
-        ...defaultState,
+        ...state,
         usernameSuggestions: state.usernameSuggestions,
         registrationFormData: { ...action.payload },
         userPipelineDataLoaded: state.userPipelineDataLoaded,

--- a/src/register/data/utils.js
+++ b/src/register/data/utils.js
@@ -54,7 +54,7 @@ export const isFormValid = (
   }
 
   Object.keys(fieldDescriptions).forEach(key => {
-    if (key === 'country' && !configurableFormFields.country.displayValue) {
+    if (key === 'country' && !configurableFormFields?.country?.displayValue) {
       fieldErrors[key] = formatMessage(messages['empty.country.field.error']);
     } else if (!configurableFormFields[key]) {
       fieldErrors[key] = fieldDescriptions[key].error_message;

--- a/src/register/messages.jsx
+++ b/src/register/messages.jsx
@@ -209,8 +209,9 @@ const messages = defineMessages({
   },
   'simplify.registration.username.guideline.content': {
     id: 'simplify.registration.username.guideline.content',
-    defaultMessage: 'To finalize your registration, please create a public username that will '
-        + 'identify you in your course communication forums. The username cannot be changed.',
+    defaultMessage: 'To finalize your registration, please confirm your country of residence '
+        + 'and create a public username that will identify you in your course communication forums. '
+        + 'The username cannot be changed.',
     description: 'Guideline content for username field in simplify registration experiment step 2',
   },
   'simplify.registration.form.submission.error': {


### PR DESCRIPTION
### Description

Moving the country field to the second step of simplify registration experiment SIMPLIFIED variation.

#### How Has This Been Tested?

Locally

#### Screenshots/sandbox (optional):

<img width="1440" alt="Screenshot 2024-03-06 at 12 12 00 PM" src="https://github.com/openedx/frontend-app-authn/assets/52817156/a14fd138-b0d8-4d94-aaef-984f16803109">
<img width="1440" alt="Screenshot 2024-03-06 at 12 12 21 PM" src="https://github.com/openedx/frontend-app-authn/assets/52817156/9a1fd478-a969-4c71-aad6-310ad1df15f4">


#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/2u-vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
