### PR TITLE
[Backport] fix: Update custom SSO buttons to use brand colors

### DIFF
--- a/src/sass/_style.scss
+++ b/src/sass/_style.scss
@@ -11,7 +11,6 @@
 // ----------------------------
 // #COLORS
 // ----------------------------
-$font-blue: #126f9a;
 $white: #FFFFFF;
 
 // social platforms
@@ -105,10 +104,10 @@ $elevation-level-2-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.15);
   font-size: 14px;
 
   background-color: $white;
-  border: 1px solid $font-blue;
+  border: 1px solid $primary;
   width: 224px;
   height: 36px;
-  color: $font-blue;
+  color: $primary;
 
   .btn-tpa__image-icon{
     background-color: transparent;
@@ -133,7 +132,7 @@ $elevation-level-2-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.15);
 }
 
 .btn-tpa__font-container {
-  background-color: $font-blue;
+  background-color: $primary;
   color: $white;
   font-size: 11px;
 


### PR DESCRIPTION
### Description

This pull request is a backport from the master branch https://github.com/openedx/frontend-app-authn/pull/1165.
The main goal is to make the buttons reflected to the primary paragon color by using the variable provided by the Paragon library.

#### Screenshots

|Before|After|
|-------|-----|
| <img width="527" alt="Screenshot at Mar 27 14-03-45" src="https://github.com/openedx/frontend-app-authn/assets/17108583/7448c521-6e77-4186-bcef-d6e13267c489">   | <img width="542" alt="Screenshot at Mar 27 14-01-11" src="https://github.com/openedx/frontend-app-authn/assets/17108583/4262a218-bb4b-4695-a871-d6dbcaca19aa"> |

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
