### PR TITLE
fix: codecov not running on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,5 @@ jobs:
 
     - name: Run Code Coverage
       uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Description

We noticed that codecov has stopped running on PRs after updating it to v4. https://github.com/codecov/codecov-action?tab=readme-ov-file#breaking-changes

This happened because tokenless uploading is unsupported in v4. 

Details: https://github.com/openedx/wg-frontend/issues/177

#### How Has This Been Tested?

This will be tested on PRs.

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/2u-vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
