### PR TITLE
fix: Prevent wrong appearance of skeleton after second tab click

### DIFF
--- a/src/logistration/Logistration.jsx
+++ b/src/logistration/Logistration.jsx
@@ -64,7 +64,10 @@ const Logistration = (props) => {
     setInstitutionLogin(!institutionLogin);
   };
 
-  const handleOnSelect = (tabKey) => {
+  const handleOnSelect = (tabKey, currentTab) => {
+    if (tabKey === currentTab) {
+      return;
+    }
     sendTrackEvent(`edx.bi.${tabKey.replace('/', '')}_form.toggled`, { category: 'user-engagement' });
     props.clearThirdPartyAuthContextErrorMessage();
     if (tabKey === LOGIN_PAGE) {
@@ -117,7 +120,7 @@ const Logistration = (props) => {
                   </Tabs>
                 )
                 : (!isValidTpaHint() && (
-                  <Tabs defaultActiveKey={selectedPage} id="controlled-tab" onSelect={handleOnSelect}>
+                  <Tabs defaultActiveKey={selectedPage} id="controlled-tab" onSelect={(tabKey) => handleOnSelect(tabKey, selectedPage)}>
                     <Tab title={formatMessage(messages['logistration.register'])} eventKey={REGISTER_PAGE} />
                     <Tab title={formatMessage(messages['logistration.sign.in'])} eventKey={LOGIN_PAGE} />
                   </Tabs>


### PR DESCRIPTION
This is backport form master - https://github.com/openedx/frontend-app-authn/pull/1086

### Description

We found that after clicking twice on the same tab - skeleton appeared and not disappeared till switching other tab or page refresh. We think that it is not logical and our proposal - this minor fix

Before fix:

https://github.com/openedx/frontend-app-authn/assets/19806032/16f7cde0-38a5-4cf9-944c-bac8879f03b6

After fix:

https://github.com/openedx/frontend-app-authn/assets/19806032/2f26ee3a-f1c7-4b24-abc1-f7ed822a9878

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
