### PR TITLE
feat: Hide preloaders for third party auth providers if they are disabled

### DIFF
--- a/src/login/LoginPage.jsx
+++ b/src/login/LoginPage.jsx
@@ -166,6 +166,7 @@ class LoginPage extends React.Component {
     const isInstitutionAuthActive = !!secondaryProviders.length && !currentProvider;
     const isSocialAuthActive = !!providers.length && !currentProvider;
     const isEnterpriseLoginDisabled = getConfig().DISABLE_ENTERPRISE_LOGIN;
+    const isThirdPartyAuthActive = isSocialAuthActive || (isEnterpriseLoginDisabled && isInstitutionAuthActive);
 
     return (
       <>
@@ -183,7 +184,7 @@ class LoginPage extends React.Component {
           </Hyperlink>
         )}
 
-        {thirdPartyAuthApiStatus === PENDING_STATE ? (
+        {thirdPartyAuthApiStatus === PENDING_STATE && isThirdPartyAuthActive ? (
           <Skeleton className="tpa-skeleton mb-3" height={30} count={2} />
         ) : (
           <>

--- a/src/register/components/ThirdPartyAuth.jsx
+++ b/src/register/components/ThirdPartyAuth.jsx
@@ -25,6 +25,7 @@ const ThirdPartyAuth = (props) => {
   const isInstitutionAuthActive = !!secondaryProviders.length && !currentProvider;
   const isSocialAuthActive = !!providers.length && !currentProvider;
   const isEnterpriseLoginDisabled = getConfig().DISABLE_ENTERPRISE_LOGIN;
+  const isThirdPartyAuthActive = isSocialAuthActive || (isEnterpriseLoginDisabled && isInstitutionAuthActive);
 
   return (
     <>
@@ -34,7 +35,7 @@ const ThirdPartyAuth = (props) => {
         </div>
       )}
 
-      {thirdPartyAuthApiStatus === PENDING_STATE ? (
+      {thirdPartyAuthApiStatus === PENDING_STATE && isThirdPartyAuthActive ? (
         <Skeleton className="tpa-skeleton" height={36} count={2} />
       ) : (
         <>


### PR DESCRIPTION
This is backport from master - https://github.com/openedx/frontend-app-authn/pull/767

### Description

Cosmetic improvements for the login/registration page. Changes in React are related to the situation when third-party login providers is disabled, but when switching between Login and Registration tabs, we still see a preloader that is not necessary in this situation.

https://user-images.githubusercontent.com/19806032/222164313-f1e985d9-47e1-4b18-8b27-8280f5c6a7fd.mov

After making our changes, we no longer see preloaders in cases where third-party login providers are turned off.

https://user-images.githubusercontent.com/19806032/222174870-e76fe894-1a63-448b-bc08-ffd9df8dca0b.mov