### PR TITLE
fix: adding value length check for full name field

### DIFF
--- a/src/register/RegistrationFields/NameField/NameField.test.jsx
+++ b/src/register/RegistrationFields/NameField/NameField.test.jsx
@@ -94,6 +94,25 @@ describe('NameField', () => {
       );
     });
 
+    it('should check for long full name error', () => {
+      const longName = `
+        5cnx16mn7qTSbtiha1W473ZtV5prGBCEtNrfLkqizJirf
+        v5kbzBpLRbdh7FY5qujb8viQ9zPziE1fWnbFu5tj4FXaY5GDESvVwjQkE
+        txUPE3r9mk4HYcSfXVJPWAWRuK2LJZycZWDm0BMFLZ63YdyQAZhjyvjn7
+        SCqKjSHDx7mgwFp35PF4CxwtwNLxY11eqf5F88wQ9k2JQ9U8uKSFyTKCM
+        A456CGA5KjUugYdT1qKdvvnXtaQr8WA87m9jpe16
+      `;
+      const { container } = render(routerWrapper(reduxWrapper(<IntlNameField {...props} />)));
+      const nameInput = container.querySelector('input#name');
+      fireEvent.blur(nameInput, { target: { value: longName, name: 'name' } });
+
+      expect(props.handleErrorChange).toHaveBeenCalledTimes(1);
+      expect(props.handleErrorChange).toHaveBeenCalledWith(
+        'name',
+        'Full name can not be longer than 255 symbols',
+      );
+    });
+
     it('should clear error on focus', () => {
       const { container } = render(routerWrapper(reduxWrapper(<IntlNameField {...props} />)));
 

--- a/src/register/RegistrationFields/NameField/validator.js
+++ b/src/register/RegistrationFields/NameField/validator.js
@@ -15,6 +15,8 @@ const validateName = (value, formatMessage) => {
     fieldError = formatMessage(messages['empty.name.field.error']);
   } else if (URL_REGEX.test(value) || HTML_REGEX.test(value) || INVALID_NAME_REGEX.test(value)) {
     fieldError = formatMessage(messages['name.validation.message']);
+  } else if (value && value.length > 255) {
+    fieldError = formatMessage(messages['name.validation.length.message']);
   }
   return fieldError;
 };

--- a/src/register/messages.jsx
+++ b/src/register/messages.jsx
@@ -126,6 +126,11 @@ const messages = defineMessages({
     defaultMessage: 'Enter a valid name',
     description: 'Validation message that appears when fullname contain URL',
   },
+  'name.validation.length.message': {
+    id: 'name.validation.message',
+    defaultMessage: 'Full name can not be longer than 255 symbols',
+    description: 'Validation message that appears when fullname contain URL',
+  },
   'password.validation.message': {
     id: 'password.validation.message',
     defaultMessage: 'Password criteria has not been met',


### PR DESCRIPTION
### Description

Fixing an error when a new user tries registering on the platform with a name longer than 255 characters.

<img width="1786" alt="500" src="https://github.com/openedx/frontend-app-authn/assets/98233552/4470a936-d3f5-4e68-987b-9f2e09c0b2f7">


Now the request to the backend will not be sent because validation fails:

<img width="1786" alt="no_created" src="https://github.com/openedx/frontend-app-authn/assets/98233552/c15af48e-7cfb-4336-b308-5283845e61df">


I also created a **[merge request to Platform](https://github.com/openedx/edx-platform/pull/34577)** so that the backend would not miss such errors. But validation on the backend is just a fuse. It’s better not to send an invalid request to the backend.