### PR TITLE
fix: retain query params in authenticated user redirection

### DIFF
--- a/src/common-components/UnAuthOnlyRoute.jsx
+++ b/src/common-components/UnAuthOnlyRoute.jsx
@@ -4,9 +4,7 @@ import { getConfig } from '@edx/frontend-platform';
 import { fetchAuthenticatedUser, getAuthenticatedUser } from '@edx/frontend-platform/auth';
 import PropTypes from 'prop-types';
 
-import {
-  DEFAULT_REDIRECT_URL,
-} from '../data/constants';
+import { updatePathWithQueryParams } from '../data/utils';
 
 /**
  * This wrapper redirects the requester to our default redirect url if they are
@@ -25,7 +23,8 @@ const UnAuthOnlyRoute = ({ children }) => {
 
   if (isReady) {
     if (authUser && authUser.username) {
-      global.location.href = getConfig().LMS_BASE_URL.concat(DEFAULT_REDIRECT_URL);
+      const updatedPath = updatePathWithQueryParams(window.location.pathname);
+      global.location.href = getConfig().LMS_BASE_URL.concat(updatedPath);
       return null;
     }
 


### PR DESCRIPTION
### Description

Retain query params in authenticated user redirection. The query params were not retained while redirecting the users to dashboard thus causing issues with enrollment flow.

#### Screenshots/sandbox (optional):

**Before:**
The enrollment URL for authn MFE is hit and the user is redirected to the dashboard instead of the enrollment page.

https://github.com/user-attachments/assets/b4f458d2-4ac2-4c33-bae8-e8745b5ef970



**After:**
The enrollment URL for authn MFE is hit and the user is successfully redirected to the enrollment page.

https://github.com/user-attachments/assets/d0834ed5-309c-49b5-991d-6411f30a04f3





#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/2u-vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
