### PR TITLE
feat: add plugin slot in authn mfe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@fortawesome/free-brands-svg-icons": "6.6.0",
         "@fortawesome/free-solid-svg-icons": "6.6.0",
         "@fortawesome/react-fontawesome": "0.2.2",
+        "@openedx/frontend-plugin-framework": "^1.2.3",
         "@openedx/paragon": "^22.1.1",
         "@optimizely/react-sdk": "^2.9.1",
         "@redux-devtools/extension": "3.3.0",
@@ -3904,6 +3905,27 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@openedx/frontend-plugin-framework": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-plugin-framework/-/frontend-plugin-framework-1.2.3.tgz",
+      "integrity": "sha512-2FBBDESusqruZHuMDNZ7SmegwXlKcrR1Po0kgEbRUGnpZKCmDnpMc8koX0vaivl7Y+XB8FBZuWV6DSC1aXwrSw==",
+      "dependencies": {
+        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
+        "classnames": "^2.3.2",
+        "core-js": "3.37.1",
+        "react-redux": "7.2.9",
+        "redux": "4.2.1",
+        "regenerator-runtime": "0.14.1"
+      },
+      "peerDependencies": {
+        "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
+        "@openedx/paragon": "^21.0.0 || ^22.0.0",
+        "prop-types": "^15.8.0",
+        "react": "^17.0.0",
+        "react-dom": "^17.0.0",
+        "react-error-boundary": "^4.0.11"
       }
     },
     "node_modules/@openedx/paragon": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@fortawesome/free-brands-svg-icons": "6.6.0",
     "@fortawesome/free-solid-svg-icons": "6.6.0",
     "@fortawesome/react-fontawesome": "0.2.2",
+    "@openedx/frontend-plugin-framework": "^1.2.3",
     "@openedx/paragon": "^22.1.1",
     "@optimizely/react-sdk": "^2.9.1",
     "@redux-devtools/extension": "3.3.0",

--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { getConfig } from '@edx/frontend-platform';
 import { AppProvider } from '@edx/frontend-platform/react';
+import { PluginSlot } from '@openedx/frontend-plugin-framework';
 import { Helmet } from 'react-helmet';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
@@ -37,26 +38,28 @@ const MainApp = () => (
       <link rel="shortcut icon" href={getConfig().FAVICON_URL} type="image/x-icon" />
     </Helmet>
     {getConfig().ZENDESK_KEY && <Zendesk />}
-    <Routes>
-      <Route path="/" element={<Navigate replace to={updatePathWithQueryParams(REGISTER_PAGE)} />} />
-      <Route
-        path={REGISTER_EMBEDDED_PAGE}
-        element={<EmbeddedRegistrationRoute><RegistrationPage /></EmbeddedRegistrationRoute>}
-      />
-      <Route
-        path={LOGIN_PAGE}
-        element={
-          <UnAuthOnlyRoute><Logistration selectedPage={LOGIN_PAGE} /></UnAuthOnlyRoute>
-        }
-      />
-      <Route path={REGISTER_PAGE} element={<UnAuthOnlyRoute><Logistration /></UnAuthOnlyRoute>} />
-      <Route path={RESET_PAGE} element={<UnAuthOnlyRoute><ForgotPasswordPage /></UnAuthOnlyRoute>} />
-      <Route path={PASSWORD_RESET_CONFIRM} element={<ResetPasswordPage />} />
-      <Route path={AUTHN_PROGRESSIVE_PROFILING} element={<ProgressiveProfiling />} />
-      <Route path={RECOMMENDATIONS} element={<RecommendationsPage />} />
-      <Route path={PAGE_NOT_FOUND} element={<NotFoundPage />} />
-      <Route path="*" element={<Navigate replace to={PAGE_NOT_FOUND} />} />
-    </Routes>
+    <PluginSlot id="widget_routes_plugin_slot">
+      <Routes>
+        <Route path="/" element={<Navigate replace to={updatePathWithQueryParams(REGISTER_PAGE)} />} />
+        <Route
+          path={REGISTER_EMBEDDED_PAGE}
+          element={<EmbeddedRegistrationRoute><RegistrationPage /></EmbeddedRegistrationRoute>}
+        />
+        <Route
+          path={LOGIN_PAGE}
+          element={
+            <UnAuthOnlyRoute><Logistration selectedPage={LOGIN_PAGE} /></UnAuthOnlyRoute>
+          }
+        />
+        <Route path={REGISTER_PAGE} element={<UnAuthOnlyRoute><Logistration /></UnAuthOnlyRoute>} />
+        <Route path={RESET_PAGE} element={<UnAuthOnlyRoute><ForgotPasswordPage /></UnAuthOnlyRoute>} />
+        <Route path={PASSWORD_RESET_CONFIRM} element={<ResetPasswordPage />} />
+        <Route path={AUTHN_PROGRESSIVE_PROFILING} element={<ProgressiveProfiling />} />
+        <Route path={RECOMMENDATIONS} element={<RecommendationsPage />} />
+        <Route path={PAGE_NOT_FOUND} element={<NotFoundPage />} />
+        <Route path="*" element={<Navigate replace to={PAGE_NOT_FOUND} />} />
+      </Routes>
+    </PluginSlot>
   </AppProvider>
 );
 


### PR DESCRIPTION
### Description

I want to include a React Component or JS file that can read cookies. But it can be done via PluginSlot which is not used in authn MFE. I have included PluginSlot in authn MFE which is wrapping `<Routes>`. I was unsure where to include it in authn MFE. I want to include where cookies can be read on any page/route. As all Routes Pages/Components doesn't have same layout, I have to include around <Routes>`. Feel free to suggest any other way but we have to sure that if I load any page of Authn MFE, code containing "read cookies" should be executed. 


#### How Has This Been Tested?

It was tested in dev by passing env.config.jsx. There is one problem I faced is that `@openedx/frontend-plugin-framework` was not installing due to deps conflict issue. So I had to install it by force. Because this package has support for `react-error-boundary` v4.x.x and  `@testing-library/react-hooks` has support for error-boundary `3.x.x`.

```jsx
import React, { useEffect } from 'react';

import { getConfig } from '@edx/frontend-platform';
import { DIRECT_PLUGIN, PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
import Cookies from 'universal-cookie';

const AddDarkTheme = () => {
  useEffect(() => {
    const cookies = new Cookies();
    if (cookies.get(getConfig().THEME_COOKIE_NAME) === 'dark') {
      document.body.classList.add('indigo-dark-theme');
    }

    return () => cookies.removeChangeListener();
  }, []);
  return (<div />);
};

const themePluginSlot = {
  keepDefault: true,
  plugins: [
    {
      op: PLUGIN_OPERATIONS.Insert,
      widget: {
        id: 'read_theme_cookie',
        type: DIRECT_PLUGIN,
        priority: 1,
        RenderWidget: AddDarkTheme,
      },
    },
  ],
};

const config = {
  pluginSlots: {
    widget_routes_plugin_slot: themePluginSlot,
  },
};

export default config;

```



#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/2u-vanguards** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.
