### PR TITLE
feat: removed Russian Federation from country list

### DIFF
--- a/src/register/components/ConfigurableRegistrationForm.jsx
+++ b/src/register/components/ConfigurableRegistrationForm.jsx
@@ -40,7 +40,10 @@ const ConfigurableRegistrationForm = (props) => {
   States' instead of 'United States of America' which does not exist in country dropdown list and gets the user
   confused and unable to create an account. So we added the United States entry in the dropdown list.
  */
-  const countryList = useMemo(() => getCountryList(getLocale()).concat([{ code: 'US', name: 'United States' }]), []);
+
+  const countryList = useMemo(() => (
+    getCountryList(getLocale()).concat([{ code: 'US', name: 'United States' }]).filter(country => country.code !== 'RU')
+  ), []);
 
   let showTermsOfServiceAndHonorCode = false;
   let showCountryField = false;


### PR DESCRIPTION
[INF-1564](https://2u-internal.atlassian.net/browse/INF-1564)

-  To ensure compliance, the country list has been updated to exclude the Russian Federation, preventing new users from registering from the Russian Federation.
- It's a temporary fix. A complete and long-term solution will be implemented in phase 2.