### PR TITLE
perf: updated cohesion id stitching script

### DIFF
--- a/src/cohesion/index.js
+++ b/src/cohesion/index.js
@@ -39,18 +39,36 @@ const CohesionScript = () => {
     // Id Stitching script (executed after the cohesionScript is loaded)
     cohesionScript.onload = () => {
       idStitching.innerHTML = `
-        window.tagular("beam", {
-          "@type": "core.Identify.v1",
-          traits: {},
-          externalIds: [
-            {
-              id: window.analytics.user().anonymousId(),
-              type: "segment_anonym_id",
-              collection: "users",
-              encoding: "none",
-            },
-          ],
-        });
+        cohesion("tagular:ready", function () {
+            window.analytics.ready(function () {
+            const cohesionAnonymId = window.tagular("getAliasSet")["anonymousId"];
+            const segmentAnonymId = window.analytics.user().anonymousId();
+                const segmentUserId = window.analytics.user().id();
+
+            window.analytics.identify(segmentUserId, {
+                  cohesion_anonymous_id: cohesionAnonymId,
+            });
+
+            window.tagular("beam", {
+              "@type": "core.Identify.v1",
+              traits: {},
+              externalIds: [
+                {
+                    id: segmentAnonymId,
+                    type: "segment_anonymous_id",
+                    collection: "users",
+                    encoding: "none",
+                },
+                {
+                    id: cohesionAnonymId,
+                    type: "cohesion_anonymous_id",
+                    collection: "users",
+                    encoding: "none",
+                },
+              ],
+            });
+            });
+          });
       `;
       document.head.appendChild(idStitching);
     };


### PR DESCRIPTION
[INF-1676](https://2u-internal.atlassian.net/browse/INF-1676)

**Description**
In the Authn MFE, we need to send a Segment Identify call that includes the Cohesion anonymous_id as a trait so that Segment is able to map Cohesion’s server-side events with Segment’s client-side events on the same page. 


In [the integration doc](https://docs.google.com/document/d/1HQtyQVrJWFgxH-4-PI5t4SMIH9thPTzc7pP3mNvkNR4/edit?tab=t.0#heading=h.d78647gr4ev3), there is a snippet of code that needs to be added to the already-existing code in Authn MFE to send Identify calls to Cohesion.