### PR TITLE
feat: implemented restricted country implementation

### DIFF
--- a/src/common-components/data/actions.js
+++ b/src/common-components/data/actions.js
@@ -13,9 +13,15 @@ export const getThirdPartyAuthContextBegin = () => ({
   type: THIRD_PARTY_AUTH_CONTEXT.BEGIN,
 });
 
-export const getThirdPartyAuthContextSuccess = (fieldDescriptions, optionalFields, thirdPartyAuthContext) => ({
+export const getThirdPartyAuthContextSuccess = (
+  fieldDescriptions,
+  optionalFields,
+  thirdPartyAuthContext,
+  countries) => ({
   type: THIRD_PARTY_AUTH_CONTEXT.SUCCESS,
-  payload: { fieldDescriptions, optionalFields, thirdPartyAuthContext },
+  payload: {
+    fieldDescriptions, optionalFields, thirdPartyAuthContext, countries,
+  },
 });
 
 export const getThirdPartyAuthContextFailure = () => ({

--- a/src/common-components/data/actions.js
+++ b/src/common-components/data/actions.js
@@ -17,10 +17,10 @@ export const getThirdPartyAuthContextSuccess = (
   fieldDescriptions,
   optionalFields,
   thirdPartyAuthContext,
-  countries) => ({
+  countriesCodesList) => ({
   type: THIRD_PARTY_AUTH_CONTEXT.SUCCESS,
   payload: {
-    fieldDescriptions, optionalFields, thirdPartyAuthContext, countries,
+    fieldDescriptions, optionalFields, thirdPartyAuthContext, countriesCodesList,
   },
 });
 

--- a/src/common-components/data/constants.js
+++ b/src/common-components/data/constants.js
@@ -77,3 +77,7 @@ export const progressiveProfilingFields = {
     },
   },
 };
+
+export const FIELD_LABELS = {
+  COUNTRY: 'country',
+};

--- a/src/common-components/data/reducers.js
+++ b/src/common-components/data/reducers.js
@@ -35,7 +35,7 @@ const reducer = (state = defaultState, action = {}) => {
         optionalFields: action.payload.optionalFields,
         thirdPartyAuthContext: action.payload.thirdPartyAuthContext,
         thirdPartyAuthApiStatus: COMPLETE_STATE,
-        countries: action.payload.countries,
+        countriesCodesList: action.payload.countriesCodesList,
       };
     }
     case THIRD_PARTY_AUTH_CONTEXT.FAILURE:

--- a/src/common-components/data/reducers.js
+++ b/src/common-components/data/reducers.js
@@ -35,6 +35,7 @@ const reducer = (state = defaultState, action = {}) => {
         optionalFields: action.payload.optionalFields,
         thirdPartyAuthContext: action.payload.thirdPartyAuthContext,
         thirdPartyAuthApiStatus: COMPLETE_STATE,
+        countries: action.payload.countries,
       };
     }
     case THIRD_PARTY_AUTH_CONTEXT.FAILURE:

--- a/src/common-components/data/sagas.js
+++ b/src/common-components/data/sagas.js
@@ -10,6 +10,7 @@ import {
 } from './actions';
 import { progressiveProfilingFields, registerFields } from './constants';
 import {
+  getCountryList,
   getThirdPartyAuthContext,
 } from './service';
 import { setCountryFromThirdPartyAuthContext } from '../../register/data/actions';
@@ -20,6 +21,7 @@ export function* fetchThirdPartyAuthContext(action) {
     const {
       fieldDescriptions, optionalFields, thirdPartyAuthContext,
     } = yield call(getThirdPartyAuthContext, action.payload.urlParams);
+    const countries = (yield call(getCountryList)) || [];
 
     yield put(setCountryFromThirdPartyAuthContext(thirdPartyAuthContext.countryCode));
     // hard code country field, level of education and gender fields
@@ -28,9 +30,10 @@ export function* fetchThirdPartyAuthContext(action) {
         registerFields,
         progressiveProfilingFields,
         thirdPartyAuthContext,
+        countries,
       ));
     } else {
-      yield put(getThirdPartyAuthContextSuccess(fieldDescriptions, optionalFields, thirdPartyAuthContext));
+      yield put(getThirdPartyAuthContextSuccess(fieldDescriptions, optionalFields, thirdPartyAuthContext, countries));
     }
   } catch (e) {
     yield put(getThirdPartyAuthContextFailure());

--- a/src/common-components/data/sagas.js
+++ b/src/common-components/data/sagas.js
@@ -21,7 +21,7 @@ export function* fetchThirdPartyAuthContext(action) {
     const {
       fieldDescriptions, optionalFields, thirdPartyAuthContext,
     } = yield call(getThirdPartyAuthContext, action.payload.urlParams);
-    const countries = (yield call(getCountryList)) || [];
+    const countriesCodesList = (yield call(getCountryList)) || [];
 
     yield put(setCountryFromThirdPartyAuthContext(thirdPartyAuthContext.countryCode));
     // hard code country field, level of education and gender fields
@@ -30,10 +30,15 @@ export function* fetchThirdPartyAuthContext(action) {
         registerFields,
         progressiveProfilingFields,
         thirdPartyAuthContext,
-        countries,
+        countriesCodesList,
       ));
     } else {
-      yield put(getThirdPartyAuthContextSuccess(fieldDescriptions, optionalFields, thirdPartyAuthContext, countries));
+      yield put(getThirdPartyAuthContextSuccess(
+        fieldDescriptions,
+        optionalFields,
+        thirdPartyAuthContext,
+        countriesCodesList,
+      ));
     }
   } catch (e) {
     yield put(getThirdPartyAuthContextFailure());

--- a/src/common-components/data/service.js
+++ b/src/common-components/data/service.js
@@ -1,5 +1,8 @@
 import { getConfig } from '@edx/frontend-platform';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { logError } from '@edx/frontend-platform/logging';
+
+import { FIELD_LABELS } from './constants';
 
 // eslint-disable-next-line import/prefer-default-export
 export async function getThirdPartyAuthContext(urlParams) {
@@ -22,4 +25,29 @@ export async function getThirdPartyAuthContext(urlParams) {
     optionalFields: data.optionalFields || {},
     thirdPartyAuthContext: data.contextData || {},
   };
+}
+
+function extractCountryList(data) {
+  return data?.fields
+    .find(({ name }) => name === FIELD_LABELS.COUNTRY)
+    ?.options?.map(({ value, name }) => ({ code: value, name })) || [];
+}
+
+export async function getCountryList() {
+  try {
+    const requestConfig = {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      isPublic: true,
+    };
+
+    const { data } = await getAuthenticatedHttpClient()
+      .get(
+      `${getConfig().LMS_BASE_URL}/user_api/v1/account/registration/`,
+      requestConfig,
+      );
+    return extractCountryList(data);
+  } catch (e) {
+    logError(e);
+    return [];
+  }
 }

--- a/src/common-components/data/service.js
+++ b/src/common-components/data/service.js
@@ -30,7 +30,7 @@ export async function getThirdPartyAuthContext(urlParams) {
 function extractCountryList(data) {
   return data?.fields
     .find(({ name }) => name === FIELD_LABELS.COUNTRY)
-    ?.options?.map(({ value, name }) => ({ code: value, name })) || [];
+    ?.options?.map(({ value }) => (value)) || [];
 }
 
 export async function getCountryList() {

--- a/src/common-components/data/tests/sagas.test.js
+++ b/src/common-components/data/tests/sagas.test.js
@@ -8,6 +8,11 @@ import * as api from '../service';
 
 const { loggingService } = initializeMockLogging();
 
+jest.mock('../service', () => ({
+  getCountryList: jest.fn(),
+  getThirdPartyAuthContext: jest.fn(),
+}));
+
 describe('fetchThirdPartyAuthContext', () => {
   const params = {
     payload: { urlParams: {} },
@@ -31,6 +36,7 @@ describe('fetchThirdPartyAuthContext', () => {
         thirdPartyAuthContext: data,
         fieldDescriptions: {},
         optionalFields: {},
+        countries: [],
       }));
 
     const dispatched = [];
@@ -44,7 +50,7 @@ describe('fetchThirdPartyAuthContext', () => {
     expect(dispatched).toEqual([
       actions.getThirdPartyAuthContextBegin(),
       setCountryFromThirdPartyAuthContext(),
-      actions.getThirdPartyAuthContextSuccess({}, {}, data),
+      actions.getThirdPartyAuthContextSuccess({}, {}, data, []),
     ]);
     getThirdPartyAuthContext.mockClear();
   });

--- a/src/common-components/data/tests/sagas.test.js
+++ b/src/common-components/data/tests/sagas.test.js
@@ -36,7 +36,7 @@ describe('fetchThirdPartyAuthContext', () => {
         thirdPartyAuthContext: data,
         fieldDescriptions: {},
         optionalFields: {},
-        countries: [],
+        countriesCodesList: [],
       }));
 
     const dispatched = [];

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -93,7 +93,7 @@ const RegistrationPage = (props) => {
   const providers = useSelector(state => state.commonComponents.thirdPartyAuthContext.providers);
   const secondaryProviders = useSelector(state => state.commonComponents.thirdPartyAuthContext.secondaryProviders);
   const pipelineUserDetails = useSelector(state => state.commonComponents.thirdPartyAuthContext.pipelineUserDetails);
-  const countries = useSelector(state => state.commonComponents.countries);
+  const countriesCodesList = useSelector(state => state.commonComponents.countriesCodesList);
 
   const backendValidations = useSelector(getBackendValidations);
   const queryParams = useMemo(() => getAllPossibleQueryParams(), []);
@@ -393,7 +393,7 @@ const RegistrationPage = (props) => {
                   setFormFields={setConfigurableFormFields}
                   autoSubmitRegisterForm={autoSubmitRegForm}
                   fieldDescriptions={fieldDescriptions}
-                  countries={countries}
+                  countriesCodesList={countriesCodesList}
                 />
                 <StatefulButton
                   id="register-user"

--- a/src/register/RegistrationPage.jsx
+++ b/src/register/RegistrationPage.jsx
@@ -93,6 +93,7 @@ const RegistrationPage = (props) => {
   const providers = useSelector(state => state.commonComponents.thirdPartyAuthContext.providers);
   const secondaryProviders = useSelector(state => state.commonComponents.thirdPartyAuthContext.secondaryProviders);
   const pipelineUserDetails = useSelector(state => state.commonComponents.thirdPartyAuthContext.pipelineUserDetails);
+  const countries = useSelector(state => state.commonComponents.countries);
 
   const backendValidations = useSelector(getBackendValidations);
   const queryParams = useMemo(() => getAllPossibleQueryParams(), []);
@@ -392,6 +393,7 @@ const RegistrationPage = (props) => {
                   setFormFields={setConfigurableFormFields}
                   autoSubmitRegisterForm={autoSubmitRegForm}
                   fieldDescriptions={fieldDescriptions}
+                  countries={countries}
                 />
                 <StatefulButton
                   id="register-user"

--- a/src/register/components/ConfigurableRegistrationForm.jsx
+++ b/src/register/components/ConfigurableRegistrationForm.jsx
@@ -37,7 +37,7 @@ const ConfigurableRegistrationForm = (props) => {
     setFieldErrors,
     setFormFields,
     autoSubmitRegistrationForm,
-    countries,
+    countriesCodesList,
   } = props;
   const dispatch = useDispatch();
 
@@ -80,12 +80,11 @@ const ConfigurableRegistrationForm = (props) => {
   }, [autoSubmitRegistrationForm]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const removeDisabledCountries = useCallback((countryList) => {
-    if (!countries.length) {
+    if (!countriesCodesList.length) {
       return countryList;
     }
-    const allowedCountries = new Set(countries.map(({ code }) => code));
-    return countryList.filter(({ code }) => allowedCountries.has(code));
-  }, [countries]);
+    return countryList.filter(({ code }) => countriesCodesList.find(x => x === code));
+  }, [countriesCodesList]);
 
   const countryList = useMemo(() => removeDisabledCountries(
     getCountryList(getLocale()).concat([{ code: 'US', name: 'United States' }])), [removeDisabledCountries]);
@@ -270,7 +269,7 @@ ConfigurableRegistrationForm.propTypes = {
   setFieldErrors: PropTypes.func.isRequired,
   setFormFields: PropTypes.func.isRequired,
   autoSubmitRegistrationForm: PropTypes.bool,
-  countries: PropTypes.arrayOf(PropTypes.shape({
+  countriesCodesList: PropTypes.arrayOf(PropTypes.shape({
     code: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
   })),
@@ -279,7 +278,7 @@ ConfigurableRegistrationForm.propTypes = {
 ConfigurableRegistrationForm.defaultProps = {
   fieldDescriptions: {},
   autoSubmitRegistrationForm: false,
-  countries: [],
+  countriesCodesList: [],
 };
 
 export default ConfigurableRegistrationForm;

--- a/src/register/components/ConfigurableRegistrationForm.jsx
+++ b/src/register/components/ConfigurableRegistrationForm.jsx
@@ -88,7 +88,7 @@ const ConfigurableRegistrationForm = (props) => {
   }, [countries]);
 
   const countryList = useMemo(() => removeDisabledCountries(
-    getCountryList(getLocale()).concat([{ code: 'US', name: 'United States' }]), []), [removeDisabledCountries]);
+    getCountryList(getLocale()).concat([{ code: 'US', name: 'United States' }])), [removeDisabledCountries]);
 
   const handleErrorChange = (fieldName, error) => {
     if (fieldName) {

--- a/src/register/components/ConfigurableRegistrationForm.jsx
+++ b/src/register/components/ConfigurableRegistrationForm.jsx
@@ -88,7 +88,7 @@ const ConfigurableRegistrationForm = (props) => {
   }, [countries]);
 
   const countryList = useMemo(() => removeDisabledCountries(
-    getCountryList(getLocale()).concat([{ code: 'US', name: 'United States' }].filter(country => country.code !== 'RU')), []), [removeDisabledCountries]);
+    getCountryList(getLocale()).concat([{ code: 'US', name: 'United States' }]), []), [removeDisabledCountries]);
 
   const handleErrorChange = (fieldName, error) => {
     if (fieldName) {

--- a/src/register/components/tests/ConfigurableRegistrationForm.test.jsx
+++ b/src/register/components/tests/ConfigurableRegistrationForm.test.jsx
@@ -192,6 +192,7 @@ describe('ConfigurableRegistrationForm', () => {
           },
         },
         autoSubmitRegistrationForm: true,
+        countries: [{ code: 'AX', name: 'Åland Islands' }, { code: 'AL', name: 'Albania' }],
       };
 
       render(routerWrapper(reduxWrapper(

--- a/src/register/components/tests/ConfigurableRegistrationForm.test.jsx
+++ b/src/register/components/tests/ConfigurableRegistrationForm.test.jsx
@@ -192,7 +192,7 @@ describe('ConfigurableRegistrationForm', () => {
           },
         },
         autoSubmitRegistrationForm: true,
-        countries: [{ code: 'AX', name: 'Åland Islands' }, { code: 'AL', name: 'Albania' }],
+        countriesCodesList: [{ code: 'AX', name: 'Åland Islands' }, { code: 'AL', name: 'Albania' }],
       };
 
       render(routerWrapper(reduxWrapper(


### PR DESCRIPTION
### Description

We are introducing a feature that allows platform administrators to restrict users from selecting one or more countries in Authn MFE.

#### How Has This Been Tested?

We retrieved the list of restricted countries by calling the following API:

👉 https://courses.edx.org/user_api/v1/account/registration/

At the same time, we obtained the translated country names using the i18n-iso-countries package.

Once both datasets were available, we filtered out the restricted countries from the translated list and displayed the updated country list in the UI.

#### Merge Checklist

* [ ] If your update includes visual changes, have they been reviewed by a designer? Send them a link to the Sandbox, if applicable.
* [ ] Is there adequate test coverage for your changes?

#### Post-merge Checklist

* [ ] Deploy the changes to prod after verifying on stage or ask **@openedx/2u-infinity** to do it. 
* [ ] 🎉 🙌 Celebrate! Thanks for your contribution.