### PR TITLE
fix: adding defer to cohesion script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
       href="<%=htmlWebpackPlugin.options.FAVICON_URL%>"
       type="image/x-icon"
     />
-    <script src="https://www.edx.org/beam-wrapper.js" ></script>
+    <script defer src="https://www.edx.org/beam-wrapper.js" ></script>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.4.4/iframeResizer.contentWindow.min.js"
       integrity="sha512-IWwZFBvHzN41wNI6etRLLuLrDDj/6AwJcPt7cmKJAzluYTIHHQ1PF8wh0rSy05jxEvvjflVvH2MxeV6riyEEXg=="


### PR DESCRIPTION
Description
[INF-1798](https://2u-internal.atlassian.net/jira/software/c/projects/INF/boards/1994?selectedIssue=INF-1798)

We're encountering an issue where the `core.Identify.v1 `call with traits isn't firing reliably. Adding the `defer` attribute to the updated Cohesion snippet might help, as it will ensure the script loads after the DOM is ready.