### PR TITLE
chore: remove husky 🪓🐶

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,6 @@
         "eslint-plugin-import": "2.31.0",
         "glob": "7.2.3",
         "history": "5.3.0",
-        "husky": "9.1.7",
         "jest": "29.7.0",
         "react-test-renderer": "^18.3.1"
       }
@@ -11362,22 +11361,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "bin.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyphenate-style-name": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,6 @@
     "dev": "PUBLIC_PATH=/authn/ MFE_CONFIG_API_URL='http://localhost:8000/api/mfe_config/v1' fedx-scripts webpack-dev-server --progress --host apps.local.openedx.io",
     "test": "fedx-scripts jest --coverage --passWithNoTests"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint"
-    }
-  },
   "author": "edX",
   "license": "AGPL-3.0",
   "homepage": "https://github.com/openedx/frontend-app-authn#readme",
@@ -79,7 +74,6 @@
     "eslint-plugin-import": "2.31.0",
     "glob": "7.2.3",
     "history": "5.3.0",
-    "husky": "9.1.7",
     "jest": "29.7.0",
     "react-test-renderer": "^18.3.1"
   }


### PR DESCRIPTION
We remove husky, which is triggering pre-push git hooks, including running "npm lint". This is causing failures when building Docker images, because "npm clean-install --omit=dev" automatically triggers "npm prepare", which attemps to run "husky". But husky is not listed in the build dependencies, only in devDependencies. As a consequence, package installation is failing with the following error:

        14.13 > @edx/frontend-app-ora-grading@0.0.1 prepare
        14.13 > husky install
        14.13
        14.15 sh: 1: husky: not found

Similar to: https://github.com/openedx/frontend-app-learning/pull/1622
