### PR TITLE
fix: fixed cohesion pageview

### DIFF
--- a/src/logistration/Logistration.jsx
+++ b/src/logistration/Logistration.jsx
@@ -70,6 +70,9 @@ const Logistration = (props) => {
     if (tabKey === currentTab) {
       return;
     }
+
+    window.tagular?.('pageView');
+
     sendTrackEvent(`edx.bi.${tabKey.replace('/', '')}_form.toggled`, { category: 'user-engagement', app_name: APP_NAME });
     props.clearThirdPartyAuthContextErrorMessage();
     if (tabKey === LOGIN_PAGE) {


### PR DESCRIPTION
[INF-1858](https://2u-internal.atlassian.net/browse/INF-1858)
### Description

A solution for the Cohesion tracking issue on the login/register page.
The problem occurs because Cohesion's pageUrl is set only on the initial page load (/login or /register) and does not automatically update when users switch tabs due to client-side routing (no browser pageView event).

To fix this, a manual pageView event needs to be triggered on the click handler for the 'Register' and 'Sign In' tabs. This forces Cohesion to update its context.