### PR TITLE
fix: fixed cohesion page url setup

### DIFF
--- a/src/MainApp.jsx
+++ b/src/MainApp.jsx
@@ -6,7 +6,7 @@ import { Helmet } from 'react-helmet';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import {
-  EmbeddedRegistrationRoute, NotFoundPage, registerIcons, UnAuthOnlyRoute,
+  EmbeddedRegistrationRoute, NotFoundPage, registerIcons, RouteTracker, UnAuthOnlyRoute,
 } from './common-components';
 import configureStore from './data/configureStore';
 import {
@@ -57,6 +57,7 @@ const MainApp = () => (
       <Route path={PAGE_NOT_FOUND} element={<NotFoundPage />} />
       <Route path="*" element={<Navigate replace to={PAGE_NOT_FOUND} />} />
     </Routes>
+    <RouteTracker />
     <MainAppSlot />
   </AppProvider>
 );

--- a/src/common-components/RouteTracker.jsx
+++ b/src/common-components/RouteTracker.jsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+import { useLocation } from 'react-router-dom';
+
+const RouteTracker = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    window.tagular?.('pageView');
+  }, [location]);
+
+  return null;
+};
+
+export default RouteTracker;

--- a/src/common-components/index.jsx
+++ b/src/common-components/index.jsx
@@ -2,6 +2,7 @@ export { default as RedirectLogistration } from './RedirectLogistration';
 export { default as registerIcons } from './RegisterFaIcons';
 export { default as EmbeddedRegistrationRoute } from './EmbeddedRegistrationRoute';
 export { default as UnAuthOnlyRoute } from './UnAuthOnlyRoute';
+export { default as RouteTracker } from './RouteTracker';
 export { default as NotFoundPage } from './NotFoundPage';
 export { default as SocialAuthProviders } from './SocialAuthProviders';
 export { default as ThirdPartyAuthAlert } from './ThirdPartyAuthAlert';

--- a/src/logistration/Logistration.jsx
+++ b/src/logistration/Logistration.jsx
@@ -71,8 +71,6 @@ const Logistration = (props) => {
       return;
     }
 
-    window.tagular?.('pageView');
-
     sendTrackEvent(`edx.bi.${tabKey.replace('/', '')}_form.toggled`, { category: 'user-engagement', app_name: APP_NAME });
     props.clearThirdPartyAuthContextErrorMessage();
     if (tabKey === LOGIN_PAGE) {


### PR DESCRIPTION
[INF-1858](https://2u-internal.atlassian.net/browse/INF-1858)

Description
A solution for the Cohesion tracking issue on the login/register page.
The problem occurs because Cohesion's pageUrl is set only on the initial page load (/login or /register) and does not automatically update when users switch tabs due to client-side routing (no browser pageView event).

To fix this, a manual pageView event needs to be triggered on the click handler for the 'Register' and 'Sign In' tabs. This forces Cohesion to update its context.