### PR TITLE
fix: add missing space symbol to the 'additional.help.text' field

### DIFF
--- a/src/forgot-password/ForgotPasswordPage.jsx
+++ b/src/forgot-password/ForgotPasswordPage.jsx
@@ -153,7 +153,7 @@ const ForgotPasswordPage = (props) => {
             )}
             <p className="mt-5.5 small text-gray-700">
               {formatMessage(messages['additional.help.text'], { platformName })}
-              <span>
+              <span className="mx-1">
                 <Hyperlink isInline destination={`mailto:${getConfig().INFO_EMAIL}`}>{getConfig().INFO_EMAIL}</Hyperlink>
               </span>
             </p>

--- a/src/forgot-password/messages.js
+++ b/src/forgot-password/messages.js
@@ -74,7 +74,7 @@ const messages = defineMessages({
   },
   'additional.help.text': {
     id: 'additional.help.text',
-    defaultMessage: 'For additional help, contact {platformName} support at ',
+    defaultMessage: 'For additional help, contact {platformName} support at',
     description: 'additional help text on forgot password page',
   },
   'sign.in.text': {


### PR DESCRIPTION
There is a issue, that almost in all translations there is no space between `"additional.help.text"` field and `{getConfig().INFO_EMAIL}` in the frontend-app-authn

<img width="1459" alt="wqa122a" src="https://github.com/user-attachments/assets/a253fea7-8586-4571-aef6-b4c2e7a324ca" />

To prevent this, and not to fix all translations files, space symbol was added.