### PR TITLE
test: Add Node 24 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [20, 24]
+    continue-on-error: ${{ matrix.node == 24 }}
 
     steps:
     - name: Checkout
@@ -18,7 +22,7 @@ jobs:
     - name: Setup Nodejs
       uses: actions/setup-node@v4
       with:
-        node-version-file: '.nvmrc'
+        node-version: ${{ matrix.node }}
 
     - name: Install Dependencies
       run: npm ci


### PR DESCRIPTION
### Description

As a first step in the upgrade to Node 24, add it to the CI matrix as a non-blocking test.

See [the tracking issue](https://github.com/openedx/frontend-app-authn/issues/1502) for further information.


