### PR TITLE
test: Remove support for Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [20, 24]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
### Description

Complete the upgrade to Node 24 by removing the Node 20 CI check and going back to using `.nvmrc` as the source of truth for which version to use.

See [the tracking issue](https://github.com/openedx/frontend-app-authn/issues/1502) for further information.
