### PR TITLE
build: remove unused @edx/reactifex package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
       },
       "devDependencies": {
         "@edx/browserslist-config": "^1.1.1",
-        "@edx/reactifex": "1.1.0",
         "@openedx/frontend-build": "^14.6.2",
         "babel-plugin-formatjs": "10.5.39",
         "eslint-plugin-import": "2.32.0",
@@ -2646,30 +2645,6 @@
       "license": "AGPL-3.0",
       "bin": {
         "atlas": "atlas"
-      }
-    },
-    "node_modules/@edx/reactifex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/reactifex/-/reactifex-1.1.0.tgz",
-      "integrity": "sha512-tXIB+lxTKNsWeMrlJ+NXAiBgvuJ7OVLxzdGMPVYPOL8Xh3BJ/S7CC1/foV8iKl0859UwshLPTAUCOn4NhgGDvw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "yargs": "^17.1.1"
-      },
-      "bin": {
-        "edx_reactifex": "main.js"
-      }
-    },
-    "node_modules/@edx/reactifex/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@edx/typescript-config": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   },
   "devDependencies": {
     "@edx/browserslist-config": "^1.1.1",
-    "@edx/reactifex": "1.1.0",
     "@openedx/frontend-build": "^14.6.2",
     "babel-plugin-formatjs": "10.5.39",
     "eslint-plugin-import": "2.32.0",


### PR DESCRIPTION
Remove @edx/reactifex package from devDependencies as it is no longer
needed. Translation extraction functionality has been verified to work
correctly without this dependency.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
