### PR TITLE
fix: simplify i18n extraction pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,5 @@
 intl_imports = ./node_modules/.bin/intl-imports.js
-transifex_utils = ./node_modules/.bin/transifex-utils.js
 i18n = ./src/i18n
-transifex_input = $(i18n)/transifex_input.json
-
-# This directory must match .babelrc .
-transifex_temp = ./temp/babel-plugin-formatjs
 
 precommit:
 	npm run lint
@@ -26,16 +21,9 @@ build: clean
 	    cp "$$f" "$$d"; \
 	  done' sh {} +
 
-i18n.extract:
-	# Pulling display strings from .jsx files into .json files...
-	rm -rf $(transifex_temp)
-	npm run-script i18n_extract
-
-i18n.concat:
-	# Gathering JSON messages into one file...
-	$(transifex_utils) $(transifex_temp) $(transifex_input)
-
-extract_translations: | requirements i18n.extract i18n.concat
+extract_translations: | requirements
+	# Pulling display strings from source files into src/i18n/transifex_input.json...
+	npm run i18n_extract
 
 # Despite the name, we actually need this target to detect changes in the incoming translated message files as well.
 detect_changed_source_translations:

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "node": "^24.12"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0-alpha.14",
+        "@openedx/frontend-base": "^1.0.0-alpha.16",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -4195,9 +4195,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.14",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.14.tgz",
-      "integrity": "sha512-VeHxEMhMgRbsfdRklbsynivhcrT16aIZEZNwecOJ3SXP3WTFkZi5GGJG5YDydQ/K/znd3ckT5TgSXipkIrtPRA==",
+      "version": "1.0.0-alpha.16",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.16.tgz",
+      "integrity": "sha512-Qs4yUfybHsOlSTsIu8fgOIqSEmAQE/YOxVRcY5VkLiDLul7KRQ0udD2ZNcUuJ0wVGuS1mGTfJNbetoJVU7uR/A==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@babel/core": "^7.24.9",
@@ -4260,7 +4260,7 @@
         "postcss-rtlcss": "^5.5.0",
         "prop-types": "^15.8.1",
         "react-dev-utils": "12.0.1",
-        "react-focus-on": "<3.10.0",
+        "react-focus-on": "^3.10.2",
         "react-intl": "^6.6.6",
         "react-refresh": "0.16.0",
         "react-refresh-typescript": "^2.0.9",
@@ -16778,24 +16778,24 @@
       }
     },
     "node_modules/react-focus-on": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.9.4.tgz",
-      "integrity": "sha512-NFKmeH6++wu8e7LJcbwV8TTd4L5w/U5LMXTMOdUcXhCcZ7F5VOvgeTHd4XN1PD7TNmdvldDu/ENROOykUQ4yQg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/react-focus-on/-/react-focus-on-3.10.2.tgz",
+      "integrity": "sha512-Ytdx2dh6yoCc2HI4Y7u5bI1xF1oeeRud52v8zQdGsyxyVC5W/dwcgQGp+CCpoLGQegwKHybH8diVj+Qn23y+hA==",
       "license": "MIT",
       "dependencies": {
-        "aria-hidden": "^1.2.2",
-        "react-focus-lock": "^2.11.3",
-        "react-remove-scroll": "^2.6.0",
-        "react-style-singleton": "^2.2.1",
+        "aria-hidden": "^1.2.5",
+        "react-focus-lock": "^2.13.7",
+        "react-remove-scroll": "^2.6.4",
+        "react-style-singleton": "^2.2.3",
         "tslib": "^2.3.1",
-        "use-sidecar": "^1.1.2"
+        "use-sidecar": "^1.1.3"
       },
       "engines": {
         "node": ">=8.5.0"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "tsc-alias": "^1.8.16"
   },
   "peerDependencies": {
-    "@openedx/frontend-base": "^1.0.0-alpha.14",
+    "@openedx/frontend-base": "^1.0.0-alpha.16",
     "@openedx/paragon": "^23",
     "@tanstack/react-query": "^5",
     "react": "^18",


### PR DESCRIPTION
## Summary

- Simplify `make extract_translations` by removing the separate `i18n.concat` step
- `@openedx/frontend-base` (as of `alpha.16`) now writes flat KV JSON directly to `src/i18n/transifex_input.json`, so the concat step and its associated `transifex-utils` dependency are no longer needed
- Bump `@openedx/frontend-base` peer dep to `^1.0.0-alpha.16` to require the version that includes this change (see [openedx/frontend-base#200](https://github.com/openedx/frontend-base/pull/200))

Verified by running `make extract_translations` on this branch and confirming `src/i18n/transifex_input.json` is written correctly. Also compared the output against upstream `master` — our branch produces a strict subset (same keys, same values; 16 keys absent due to source code removed in the `frontend-base` branch, zero conflicts).

## Test plan

- [ ] Run `make extract_translations` and verify `src/i18n/transifex_input.json` is generated in flat KV format

<details>
<summary><h3>Log</h3></summary>

# extract-translations work log

**Repo:** `frontend-app-authn` — branch `extract-translations` (off `frontend-base`)

**Goal:** Get `make extract_translations` working on the `frontend-base` branch, using the pattern established in [openedx/paragon#4177](https://github.com/openedx/paragon/pull/4177).

## Background

Standard MFEs use a two-step pipeline via `make extract_translations`:
1. `i18n.extract` — runs `fedx-scripts formatjs extract` (from `frontend-build`), outputs an array of `{id, defaultMessage, description}` objects to `./temp/babel-plugin-formatjs/Default.messages.json`
2. `i18n.concat` — runs `transifex-utils.js` (from `frontend-platform`), reads that array and writes flat KV to `src/i18n/transifex_input.json`

The `frontend-base` branch doesn't have `frontend-platform` or `frontend-build` available, so this pipeline breaks.

## Error (current, on `frontend-base` branch without this fix)

`make extract_translations` fails at the `i18n.concat` step:

```
Error: Found no messages
    at Object.<anonymous> (.../node_modules/@openedx/frontend-base/dist/tools/cli/transifex-utils.js:38:11)
```

## Investigation findings

- `i18n_extract` in `package.json` runs `openedx formatjs extract` (from `@openedx/frontend-base` CLI)
- That command writes to `./temp/formatjs/Default.messages.json`
- The Makefile's `i18n.concat` step passes `./temp/babel-plugin-formatjs` to `transifex-utils.js` — that directory never gets created, so it throws `Found no messages`
- **Root cause: path mismatch** — the Makefile still references the old `frontend-build`-era path `./temp/babel-plugin-formatjs`, but `frontend-base`'s CLI writes to `./temp/formatjs`

The fix in [openedx/frontend-base#200](https://github.com/openedx/frontend-base/pull/200) sidesteps this entirely — the formatter now outputs flat KV directly to `src/i18n/transifex_input.json`, removing the need for the concat step altogether.

## Verification

- Ran `make extract_translations` on `frontend-base` branch (without fix): ❌ `Error: Found no messages`
- Ran `make extract_translations` on upstream `master`: ✅ passes
- Ran `make extract_translations` on this branch (`extract-translations`): ✅ passes
- Compared output against upstream `master`: our branch is a strict subset — same keys, same values, zero conflicts (16 keys absent due to source code removed in the `frontend-base` branch)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)