### PR TITLE
build: add semantic-release for automated npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release CI
+on:
+  push:
+    branches:
+      - frontend-base
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: write  # For Semantic Release tagging
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Release to npm/Github
+        run: npx semantic-release@25
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,13 @@
+{
+  "branches": [
+    "placeholder",
+    { "name": "frontend-base", "prerelease": "alpha", "channel": "latest" }
+  ],
+  "tagFormat": "v${version}",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/npm",
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
### Description

Adds `.releaserc` and a GitHub Actions release workflow to automate versioning and npm publishing via [semantic-release](https://github.com/semantic-release/semantic-release).

Releases are triggered on push to the `frontend-base` branch, publishing to the `latest` dist-tag as `alpha` prereleases. A `placeholder` branch exists on the repo to satisfy semantic-release's requirement for at least one non-prerelease branch. The `refs/notes/semantic-release` git note has been added to the commit at `v1.0.0-alpha.6` to inform semantic-release of the channel history for existing tags.

The workflow uses OIDC for npm publishing (no `NPM_TOKEN` needed) and `OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN` for GitHub releases.

More info in the parent issue: https://github.com/openedx/frontend-base/issues/174

### LLM usage notice

Built with assistance from Claude.