### PR TITLE
feat: hide shell header and footer dynamically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4395,9 +4395,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.23",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.23.tgz",
-      "integrity": "sha512-d74micKvGDLZdHkZfI2o1q2hiYzLUSkNuvOs56rFod6PLSa3F4qgrsKE9sa5hAHHMpZdq1q821irbId93QdHTg==",
+      "version": "1.0.0-alpha.24",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.24.tgz",
+      "integrity": "sha512-GD2RFPgPtaRHQ/q0WBlDKoT0MX8m5qdVM5+3g6GfcAJJhIUdKBDtmELX8jkn7YWUIGdj8f4iOvsepXqx0MYPJQ==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,12 @@
 import { App } from '@openedx/frontend-base';
 import { appId } from './constants';
+import provides from './provides';
 import routes from './routes';
 
 const app: App = {
   appId,
   routes,
+  provides,
   config: {
     ACTIVATION_EMAIL_SUPPORT_LINK: null,
     ALLOW_PUBLIC_ACCOUNT_CREATION: true,

--- a/src/provides.ts
+++ b/src/provides.ts
@@ -1,0 +1,14 @@
+import { providesChromelessRolesId } from '@openedx/frontend-base';
+import {
+  confirmPasswordRole,
+  loginRole,
+  registerRole,
+  resetPasswordRole,
+  welcomeRole,
+} from './constants';
+
+const provides = {
+  [providesChromelessRolesId]: [loginRole, registerRole, resetPasswordRole, confirmPasswordRole, welcomeRole],
+};
+
+export default provides;


### PR DESCRIPTION
### Description

Uses the new `provides` mechanism from frontend-base to declare which authn roles should trigger chromeless mode (no shell header or footer). All five authn roles (login, register, resetPassword, confirmPassword, welcome) are listed under `providesChromelessRolesId`, preserving the existing behavior where header and footer are hidden on all authn pages.

Depends on openedx/frontend-base#220.

### LLM usage notice

Built with assistance from Claude.