### PR TITLE
fix: use roles array in route handle config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4395,9 +4395,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.24",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.24.tgz",
-      "integrity": "sha512-GD2RFPgPtaRHQ/q0WBlDKoT0MX8m5qdVM5+3g6GfcAJJhIUdKBDtmELX8jkn7YWUIGdj8f4iOvsepXqx0MYPJQ==",
+      "version": "1.0.0-alpha.26",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.26.tgz",
+      "integrity": "sha512-fJPEpLyeCSVDAFVu83kwHQjMEzwCpjbiKD7GRpMZX27bLu9tkNvkssVqxyvZgu/ebAsLN4ga6xTT/34+DLyyZw==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {
@@ -4412,6 +4412,7 @@
         "@formatjs/ts-transformer": "^3.13.14",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
         "@stylistic/eslint-plugin": "^2.9.0",
+        "@tanstack/react-query-devtools": "^5.99.0",
         "@types/eslint__js": "^8.42.3",
         "@types/gradient-string": "^1.1.6",
         "@types/lodash.keyby": "^4.6.9",
@@ -5387,9 +5388,20 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.90.20",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
-      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
+      "integrity": "sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.99.0.tgz",
+      "integrity": "sha512-m4ufXaJ8FjWXw7xDtyzE/6fkZAyQFg9WrbMrUpt8ZecRJx58jiFOZ2lxZMphZdIpAnIeto/S8stbwLKLusyckQ==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -5398,19 +5410,37 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.90.21",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
-      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.0.tgz",
+      "integrity": "sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@tanstack/query-core": "5.90.20"
+        "@tanstack/query-core": "5.99.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.99.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.99.0.tgz",
+      "integrity": "sha512-CqqX7LCU9yOfCY/vBURSx2YSD83ryfX+QkfkaKionTfg1s2Hdm572Ro99gW3QPoJjzvsj1HM4pnN4nbDy3MXKA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@tanstack/query-devtools": "5.99.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.99.0",
         "react": "^18 || ^19"
       }
     },

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -28,7 +28,7 @@ const routes = [
       {
         path: loginPath,
         handle: {
-          role: loginRole,
+          roles: [loginRole],
         },
         element: (
           <UnAuthOnlyRoute><Logistration selectedPage={loginPath} /></UnAuthOnlyRoute>
@@ -37,7 +37,7 @@ const routes = [
       {
         path: registerPath,
         handle: {
-          role: registerRole,
+          roles: [registerRole],
         },
         element: (
           <UnAuthOnlyRoute><Logistration /></UnAuthOnlyRoute>
@@ -46,7 +46,7 @@ const routes = [
       {
         path: resetPath,
         handle: {
-          role: resetPasswordRole,
+          roles: [resetPasswordRole],
         },
         element: (
           <UnAuthOnlyRoute><ForgotPasswordPage /></UnAuthOnlyRoute>
@@ -55,7 +55,7 @@ const routes = [
       {
         path: `${passwordResetConfirmPath}/:token`,
         handle: {
-          role: confirmPasswordRole,
+          roles: [confirmPasswordRole],
         },
         element: (
           <ResetPasswordPage />
@@ -64,7 +64,7 @@ const routes = [
       {
         path: welcomePath,
         handle: {
-          role: welcomeRole,
+          roles: [welcomeRole],
         },
         element: (
           <ProgressiveProfiling />


### PR DESCRIPTION
### Description

The latest version of frontend-base expects route handle objects to use `roles: [role]` instead of the previous `role: role` format. This updates all five route handle configurations in `routes.jsx` accordingly, and bumps the `package-lock.json` to frontend-base alpha.26.

### LLM usage notice

Built with assistance from Claude.