### PR TITLE
fix: let composing site own shell and brand CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/*"
       ],
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/openedx-atlas": "^0.7.0",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",
@@ -2257,13 +2256,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@edx/brand": {
-      "name": "@openedx/brand-openedx",
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
-      "license": "GPL-3.0-or-later"
-    },
     "node_modules/@edx/browserslist-config": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@edx/browserslist-config/-/browserslist-config-1.5.1.tgz",
@@ -4395,9 +4387,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.26",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.26.tgz",
-      "integrity": "sha512-fJPEpLyeCSVDAFVu83kwHQjMEzwCpjbiKD7GRpMZX27bLu9tkNvkssVqxyvZgu/ebAsLN4ga6xTT/34+DLyyZw==",
+      "version": "1.0.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.33.tgz",
+      "integrity": "sha512-eTjdN4tx4zdUA0IgtEKDE4reYsG0ZLsSc62eFXyt1kbHj6UaKEn0WjPotp/2zDLMsk+BcQ7V/LQEVps6FRGK7Q==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {
@@ -4440,7 +4432,7 @@
         "glob": "^7.2.3",
         "globals": "^15.11.0",
         "gradient-string": "^2.0.2",
-        "html-webpack-plugin": "5.6.0",
+        "html-webpack-plugin": "5.6.7",
         "identity-obj-proxy": "3.0.0",
         "image-minimizer-webpack-plugin": "3.8.3",
         "jest": "^29.7.0",
@@ -11932,9 +11924,9 @@
       }
     },
     "node_modules/html-webpack-plugin": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.0.tgz",
-      "integrity": "sha512-iwaY4wzbe48AfKLZ/Cc8k0L+FKG6oSNRaZ8x5A/T/IVDGyXcbHncM9TdDa93wn0FsSm82FhTKW7f3vS61thXAw==",
+      "version": "5.6.7",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.6.7.tgz",
+      "integrity": "sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "url": "git+https://github.com/openedx/frontend-app-authn.git"
   },
   "exports": {
-    ".": "./dist/index.js",
-    "./app.scss": "./dist/app.scss"
+    ".": "./dist/index.js"
   },
   "files": [
     "/dist"
@@ -59,7 +58,6 @@
     "url": "https://github.com/openedx/frontend-app-authn/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
     "@edx/openedx-atlas": "^0.7.0",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-brands-svg-icons": "^6.7.2",

--- a/site.config.dev.tsx
+++ b/site.config.dev.tsx
@@ -2,7 +2,7 @@ import { EnvironmentTypes, SiteConfig } from '@openedx/frontend-base';
 
 import { authnApp } from './src';
 
-import './src/app.scss';
+import '@openedx/frontend-base/shell/style';
 
 const siteConfig: SiteConfig = {
   siteId: 'authn-dev',

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -6,7 +6,7 @@ import {
   registerIcons,
 } from './common-components';
 
-import './sass/_style.scss';
+import './style.scss';
 
 registerIcons();
 

--- a/src/app.scss
+++ b/src/app.scss
@@ -1,2 +1,0 @@
-@use "@openedx/frontend-base/shell/app.scss";
-@use "./sass/style";

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -15,7 +15,7 @@ const routes = [
     id: 'org.openedx.frontend.route.authn.main',
     path: '/authn',
     async lazy() {
-      const module = await import('./Main');
+      const module = await import(/* webpackChunkName: "authn-main" */ './Main');
       return { Component: module.default };
     },
     children: [

--- a/src/sass/_base_component.scss
+++ b/src/sass/_base_component.scss
@@ -59,7 +59,7 @@
   margin-bottom: 0.5rem;
   font-weight: 700;
 
-  @media (-pgn-size-breakpoint-max-width-xl) {
+  @media (--pgn-size-breakpoint-max-width-xl) {
     font-size: 1.375rem;
     line-height: 1.75rem;
   }
@@ -71,7 +71,7 @@
 }
 
 .large-screen-left-container {
-  @media (-pgn-size-breakpoint-max-width-xl) {
+  @media (--pgn-size-breakpoint-max-width-xl) {
     flex: 0 0 25%;
     max-width: 25%;
   }

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,10 +1,12 @@
+@use "@openedx/paragon/styles/css/core/custom-media-breakpoints.css";
+
 // Load component based styles
-@use "_base_component.scss";
-@use "_registration.scss";
-@use "_reset_password.scss";
-@use "_progressive_profiling_page.scss";
-@use "_login_page.scss";
-@use "_forgot_password.scss";
+@use "./sass/base_component";
+@use "./sass/registration";
+@use "./sass/reset_password";
+@use "./sass/progressive_profiling_page";
+@use "./sass/login_page";
+@use "./sass/forgot_password";
 
 //
 // ----------------------------


### PR DESCRIPTION
### Description

Stops the app from re-bundling the shell stylesheet so lazy-loaded app chunks no longer re-declare Paragon's `:root` custom properties and clobber the composing site's brand tokens at runtime. The dev harness now pulls the shell styles in through `@openedx/frontend-base/shell/style` (a JS manifest exposed by frontend-base) directly from `site.config.dev.tsx`, while app-scoped styles continue to load per-chunk through `Main.tsx` via `src/style.scss`. The `./app.scss` subpath export and the `src/app.scss` entry are both removed since composing sites no longer need to pull in the app's rules at site-build time.

Also fixes two `@media` queries in `_base_component.scss` that used a single-dash custom-media name (`-pgn-...`) and were silently non-matching.

The dev harness runs unbranded now, so `@edx/brand` is dropped from the repo entirely rather than demoted to a devDependency.

Refs openedx/frontend-base#232.

### LLM usage notice

Built with assistance from Claude.