### PR TITLE
chore: add build:ci smoke test to verify webpack build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
     - name: Build
       run: npm run build
 
+    - name: Build (CI)
+      run: npm run build:ci
+
     - name: Run Code Coverage
       uses: codecov/codecov-action@v5
       with:

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ build:
 	    cp "$$f" "$$d"; \
 	  done' sh {} +
 
+build-ci:
+	SITE_CONFIG_PATH=site.config.ci.tsx openedx build
+
 extract_translations: | requirements
 	# Pulling display strings from source files into src/i18n/transifex_input.json...
 	npm run i18n_extract

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "scripts": {
     "build": "make build",
+    "build:ci": "make build-ci",
     "build:packages": "make build-packages",
     "clean": "make clean",
     "clean:packages": "make clean-packages",

--- a/site.config.ci.tsx
+++ b/site.config.ci.tsx
@@ -5,14 +5,14 @@ import { authnApp } from './src';
 import '@openedx/frontend-base/shell/style';
 
 const siteConfig: SiteConfig = {
-  siteId: 'authn-dev',
-  siteName: 'Authn Dev',
-  baseUrl: 'http://apps.local.openedx.io:8080',
-  lmsBaseUrl: 'http://local.openedx.io:8000',
-  loginUrl: 'http://local.openedx.io:8000/login',
-  logoutUrl: 'http://local.openedx.io:8000/logout',
+  siteId: 'authn-ci',
+  siteName: 'Authn CI',
+  baseUrl: 'http://apps.local.openedx.io',
+  lmsBaseUrl: 'http://local.openedx.io',
+  loginUrl: 'http://local.openedx.io/login',
+  logoutUrl: 'http://local.openedx.io/logout',
 
-  environment: EnvironmentTypes.DEVELOPMENT,
+  environment: EnvironmentTypes.PRODUCTION,
   apps: [
     shellApp,
     headerApp,


### PR DESCRIPTION
### Description

Apps are distributed build-less, so `npm run build` only compiles the library `dist/` via `tsc` and nothing in CI verifies that the app can actually be webpack-bundled as a deployable site. This PR adds an `npm run build:ci` script that exercises the real app graph through webpack, and wires it into the CI workflow after the existing build step.

Refs openedx/frontend-base#124.

### Verifying the check

Introduce a typo in an import in `src/routes.jsx` (for example, change `from './forgot-password'` to `from './forgot-password-typo'`). `npm run build` still passes, but `npm run build:ci` fails with a module resolution error. Revert the typo and the build goes green again.

### LLM usage notice

Built with assistance from Claude.