### PR TITLE
fix: set document title via Helmet on the not-found route

### DIFF
--- a/src/common-components/NotFoundPage.jsx
+++ b/src/common-components/NotFoundPage.jsx
@@ -1,15 +1,28 @@
-import { FormattedMessage } from '@openedx/frontend-base';
+import { FormattedMessage, getSiteConfig, useIntl } from '@openedx/frontend-base';
+import { Helmet } from 'react-helmet';
 
-const NotFoundPage = () => (
-  <div className="container-fluid d-flex py-5 justify-content-center align-items-start text-center">
-    <p className="my-0 py-5 text-muted mw-32em">
-      <FormattedMessage
-        id="error.notfound.message"
-        defaultMessage="The page you're looking for is unavailable or there's an error in the URL. Please check the URL and try again."
-        description="error message when a page does not exist"
-      />
-    </p>
-  </div>
-);
+import messages from './messages';
+
+const NotFoundPage = () => {
+  const { formatMessage } = useIntl();
+  return (
+    <div className="container-fluid d-flex py-5 justify-content-center align-items-start text-center">
+      <Helmet>
+        <title>
+          {formatMessage(messages['error.notfound.page.title'], {
+            siteName: getSiteConfig().siteName,
+          })}
+        </title>
+      </Helmet>
+      <p className="my-0 py-5 text-muted mw-32em">
+        <FormattedMessage
+          id="error.notfound.message"
+          defaultMessage="The page you're looking for is unavailable or there's an error in the URL. Please check the URL and try again."
+          description="error message when a page does not exist"
+        />
+      </p>
+    </div>
+  );
+};
 
 export default NotFoundPage;

--- a/src/common-components/messages.jsx
+++ b/src/common-components/messages.jsx
@@ -1,6 +1,12 @@
 import { defineMessages } from '@openedx/frontend-base';
 
 const messages = defineMessages({
+  // not found page
+  'error.notfound.page.title': {
+    id: 'error.notfound.page.title',
+    defaultMessage: 'Page Not Found | {siteName}',
+    description: 'Document title for the page-not-found page',
+  },
   // institution login strings
   'institution.login.page.sub.heading': {
     id: 'institution.login.page.sub.heading',


### PR DESCRIPTION
### Description

Refs openedx/frontend-base#250.

`NotFoundPage` was the only route child in authn that didn't render a `<Helmet>` block, so `/authn/notfound` kept whatever document title the previous page had set.  This PR closes the gap by adding the same `<Helmet>` pattern the other authn pages already follow, with a new `error.notfound.page.title` message defaulting to `Page Not Found | {siteName}`.

The pattern is set out in [frontend-base ADR 0015](https://github.com/openedx/frontend-base/blob/main/docs/decisions/0015-page-titles-via-helmet.rst).

### LLM usage notice

Built with assistance from Claude.