### PR TITLE
chore: downgrade @openedx/brand-openedx to ^1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/brand": "npm:@openedx/brand-openedx@^2.0.0",
+        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
         "@edx/frontend-platform": "^8.7.0",
         "@edx/openedx-atlas": "^0.6.0",
         "@fortawesome/fontawesome-svg-core": "6.7.2",
@@ -2506,9 +2506,9 @@
     },
     "node_modules/@edx/brand": {
       "name": "@openedx/brand-openedx",
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-2.0.4.tgz",
-      "integrity": "sha512-3iGs4ZjfOsyN1msP+Wn/k11qL4g0CJGpKWGH5f248n+dZrGzZnhyz2CEo4TCRRMqOcQroSX5WBIuZR4vUla0Sg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
+      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/browserslist-config": {
@@ -6930,13 +6930,6 @@
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-error-boundary": "^4.0.11"
       }
-    },
-    "node_modules/@openedx/frontend-plugin-framework/node_modules/@edx/brand": {
-      "name": "@openedx/brand-openedx",
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
-      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
-      "license": "GPL-3.0-or-later"
     },
     "node_modules/@openedx/frontend-plugin-framework/node_modules/core-js": {
       "version": "3.37.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/openedx/frontend-app-authn/issues"
   },
   "dependencies": {
-    "@edx/brand": "npm:@openedx/brand-openedx@^2.0.0",
+    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.3",
     "@edx/frontend-platform": "^8.7.0",
     "@edx/openedx-atlas": "^0.6.0",
     "@fortawesome/fontawesome-svg-core": "6.7.2",


### PR DESCRIPTION
### Description

Reverts the `@openedx/brand-openedx` v2 bump landed via openedx/public-engineering#505. The package is downgraded to the latest 1.x release (`^1.2.3`) while preserving the existing `@edx/brand` -> `@openedx/brand-openedx` npm alias. The `frontend-build` and `frontend-platform` bumps from #505 are unaffected.

Tracked by openedx/public-engineering#508.

### LLM usage notice

Built with assistance from Claude.