### PR TITLE
fix: publish stable releases from a release/frontend-base branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - frontend-base
+      - release/frontend-base
 
 permissions:
   id-token: write  # Required for OIDC

--- a/.releaserc
+++ b/.releaserc
@@ -1,7 +1,7 @@
 {
   "branches": [
-    "placeholder",
-    { "name": "frontend-base", "prerelease": "alpha", "channel": "latest" }
+    { "name": "release/frontend-base", "channel": "latest" },
+    { "name": "frontend-base", "prerelease": "alpha", "channel": "alpha" }
   ],
   "tagFormat": "v${version}",
   "plugins": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "node": "^24.12"
       },
       "peerDependencies": {
-        "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+        "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
         "@openedx/paragon": "^23",
         "@tanstack/react-query": "^5",
         "react": "^18",
@@ -4387,9 +4387,9 @@
       }
     },
     "node_modules/@openedx/frontend-base": {
-      "version": "1.0.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.0-alpha.33.tgz",
-      "integrity": "sha512-eTjdN4tx4zdUA0IgtEKDE4reYsG0ZLsSc62eFXyt1kbHj6UaKEn0WjPotp/2zDLMsk+BcQ7V/LQEVps6FRGK7Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@openedx/frontend-base/-/frontend-base-1.0.1.tgz",
+      "integrity": "sha512-Xi5D2SqXxTgbGzZRM3F0oSCJkR+6KWnGULAmfw3TQOkmJ43jDIZ0BZ1XrJySScaSXkibG4OZCtcHSjV4IHgm/g==",
       "license": "AGPL-3.0",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "turbo": "^2.8.16"
   },
   "peerDependencies": {
-    "@openedx/frontend-base": "^1.0.0-alpha || 0.0.0-dev",
+    "@openedx/frontend-base": "^1.0.0 || 0.0.0-dev",
     "@openedx/paragon": "^23",
     "@tanstack/react-query": "^5",
     "react": "^18",


### PR DESCRIPTION
### Description

Adopts the release-branch model from ADR 0012 so `@openedx/frontend-app-authn` can publish a stable `1.0.0`. Stable releases publish to npm `@latest` from a long-lived `release/frontend-base` branch, while the `frontend-base` dev branch publishes `-alpha` prereleases to `@alpha`.

`.releaserc` replaces the `placeholder` entry with a `release/frontend-base` release branch and sets the `frontend-base` prerelease branch's dist-tag explicitly to `alpha` (previously `latest`, which sent alphas to `@latest`). The release workflow now triggers on both `frontend-base` and `release/frontend-base`.

The branch is named `release/frontend-base` rather than a bare `release` because the repo already has `release/*` branches (`release/teak`, `release/ulmo`, `release/verawood`); git cannot store a `release` ref alongside the `release/` directory those occupy. The nested name is still non-`n.x`, so semantic-release treats it as a release branch that can originate the `1.0.0` major.

Also bumps the `@openedx/frontend-base` peer dependency from `^1.0.0-alpha` to `^1.0.0` (the released stable is `1.0.1`).

Part of openedx/frontend-app-authn#1675.

### LLM usage notice

Built with assistance from Claude models (mostly Opus 4.8).
